### PR TITLE
Bug fixes

### DIFF
--- a/PIETOOLS_2021b/executives/PIETOOLS_Hinf_control.m
+++ b/PIETOOLS_2021b/executives/PIETOOLS_Hinf_control.m
@@ -104,6 +104,7 @@ end
 % In this case, we define the hinf norm variable which needs to be minimized
 dpvar gam;
 prog = sosdecvar(prog, gam); %this sets gamma as decision var
+prog = sosineq(prog, gam); %this ensures gamma is lower bounded
 prog = sossetobj(prog, gam); %this minimizes gamma, comment for feasibility test
 %
 % Alternatively, the above 3 commands may be commented and a specific gain

--- a/PIETOOLS_2021b/executives/PIETOOLS_Hinf_estimator.m
+++ b/PIETOOLS_2021b/executives/PIETOOLS_Hinf_estimator.m
@@ -98,6 +98,7 @@ ny=C2op.dim(1,1);                % retrieve the number of real-valued observed o
 % In this case, we define the hinf norm variable which needs to be minimized
 dpvar gam;
 prog = sosdecvar(prog, gam); %this sets gamma as decision var
+prog = sosineq(prog, gam); %this ensures gamma is lower bounded
 prog = sossetobj(prog, gam); %this minimizes gamma, comment for feasibility test
 %
 % Alternatively, the above 3 commands may be commented and a specific gain

--- a/PIETOOLS_2021b/executives/PIETOOLS_Hinf_gain.m
+++ b/PIETOOLS_2021b/executives/PIETOOLS_Hinf_gain.m
@@ -86,6 +86,7 @@ nz=C1op.dim(1,1);                % retrieve the number of real-valued regulated 
 % In this case, we define the hinf norm variable which needs to be minimized
 dpvar gam;
 prog = sosdecvar(prog, gam); %this sets gam = gamma as decision var
+prog = sosineq(prog, gam); %this ensures gamma is lower bounded
 prog = sossetobj(prog, gam); %this minimizes gamma, comment for feasibility test
 %
 % Alternatively, the above 3 commands may be commented and a specific gain

--- a/PIETOOLS_2021b/executives/PIETOOLS_Hinf_gain_dual.m
+++ b/PIETOOLS_2021b/executives/PIETOOLS_Hinf_gain_dual.m
@@ -105,6 +105,7 @@ end
 % In this case, we define the hinf norm variable which needs to be minimized
 dpvar gam;
 prog = sosdecvar(prog, gam); %this sets gamma as decision var
+prog = sosineq(prog, gam); %this ensures gamma is lower bounded
 prog = sossetobj(prog, gam); %this minimizes gamma, comment for feasibility test
 %
 % Alternatively, the above 3 commands may be commented and a specific gain

--- a/PIETOOLS_2021b/executives/PIETOOLS_auto_execute.m
+++ b/PIETOOLS_2021b/executives/PIETOOLS_auto_execute.m
@@ -33,6 +33,7 @@
 % authorship, and a brief description of modifications
 %
 % Initial coding DJ - 12/22/2021
+% Updated to enforce separability for control/estimator, SS/DJ - 01/13/2022
 %
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 % % % 1. Check if a PIE has been specified
@@ -78,13 +79,9 @@ if exist('Hinf_gain_dual','var') && Hinf_gain_dual==1
     exec = [exec;'Hinf_gain_dual'];
 end
 if exist('Hinf_estimator','var') && Hinf_estimator==1
-    settings.options1.sep=1; %needed to ensure the P is invertible -SS
-    settings.options2.sep=1;
     exec = [exec;'Hinf_estimator'];
 end
 if exist('Hinf_control','var') && Hinf_control==1
-    settings.options1.sep=1; %needed to ensure the P is invertible -SS
-    settings.options2.sep=1;
     exec = [exec;'Hinf_control'];
 end
 
@@ -107,6 +104,16 @@ if ~exist('settings','var')
     sttngs = input(msg,'s');
     sttngs = strrep(sttngs,'''','');    % Get rid of potential apostrophes
     evalin('base',['settings_PIETOOLS_',sttngs]);   % Construct the settings
+end
+
+% % Ensure separability is enforced for estimator/control executives
+if exist('Hinf_estimator','var') && Hinf_estimator==1
+    settings.options1.sep = 1; %needed to ensure the P is invertible -SS
+    settings.options2.sep = 1;
+end
+if exist('Hinf_control','var') && Hinf_control==1
+    settings.options1.sep = 1; %needed to ensure the P is invertible -SS
+    settings.options2.sep = 1;
 end
 
 % % Check if LF positivity and negativity strictness conditions have been

--- a/PIETOOLS_2021b/executives/PIETOOLS_auto_execute.m
+++ b/PIETOOLS_2021b/executives/PIETOOLS_auto_execute.m
@@ -78,9 +78,13 @@ if exist('Hinf_gain_dual','var') && Hinf_gain_dual==1
     exec = [exec;'Hinf_gain_dual'];
 end
 if exist('Hinf_estimator','var') && Hinf_estimator==1
+    settings.options1.sep=1; %needed to ensure the P is invertible -SS
+    settings.options2.sep=1;
     exec = [exec;'Hinf_estimator'];
 end
 if exist('Hinf_control','var') && Hinf_control==1
+    settings.options1.sep=1; %needed to ensure the P is invertible -SS
+    settings.options2.sep=1;
     exec = [exec;'Hinf_control'];
 end
 


### PR DESCRIPTION
Two major modifications: 

A) Modified auto_execute to always use settings.sep=1 when a controller or observer problem is being solved

B) Modified all hinf-executives to constrain gamma>0 so that if outputs and disturbances are zero then the LPI solves a stability test (in case of hinf-gain problems), stabilizing controller (in case of hinf-control), and stable observer (in case of hinf-observer)

Modified files are listed below:
PIETOOLS_auto_execute.m
PIETOOLS_hinf_gain.m
PIETOOLS_hinf_gain_dual.m
PIETOOLS_hinf_control.m
PIETOOLS_hinf_estimator.m
