### PR TITLE
Opvar auto-initialization fixes

### DIFF
--- a/PIETOOLS_2021b/opvar/@dopvar/ctranspose.m
+++ b/PIETOOLS_2021b/opvar/@dopvar/ctranspose.m
@@ -1,4 +1,4 @@
-function [P] = ctranspose(P)
+function [Pt] = ctranspose(P)
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 % P] = ctranspose(P) transposes an operator P: R^p x L2^q to R^m x L2^n
 % Date: 6/13/19
@@ -45,12 +45,12 @@ if ~isa(P,'dopvar')
     error('Input must be an opvar variable.');
 end
 
-P.P = P.P';
-Q2 = P.Q2;
-P.Q2 = P.Q1';
-P.Q1 = Q2';
-P.R.R0 = P.R.R0';
-R2 = P.R.R2;
-P.R.R2 = var_swap(P.R.R1',P.var1, P.var2);
-P.R.R1 = var_swap(R2',P.var1, P.var2);
+dopvar Pt; Pt.I = P.I; Pt.var1= P.var1; Pt.var2 = P.var2;
+
+Pt.P = P.P';
+Pt.Q2 = P.Q1';
+Pt.Q1 = P.Q2';
+Pt.R.R0 = P.R.R0';
+Pt.R.R2 = var_swap(P.R.R1',P.var1, P.var2);
+Pt.R.R1 = var_swap(P.R.R2',P.var1, P.var2);
 end

--- a/PIETOOLS_2021b/opvar/@dopvar/dopvar.m
+++ b/PIETOOLS_2021b/opvar/@dopvar/dopvar.m
@@ -57,6 +57,9 @@ classdef (InferiorClasses={?polynomial,?dpvar,?opvar}) dopvar
         var2 polynomial = pvar('theta');
         dim(2,2) double = [0 0; 0 0];
     end
+    properties (Hidden)
+        internal_call = 0;
+    end
     properties (Dependent)
         dimdependent;
     end
@@ -74,15 +77,27 @@ classdef (InferiorClasses={?polynomial,?dpvar,?opvar}) dopvar
         end
         function [obj] = set.P(obj,P) 
             obj.P = P;
+            if ~obj.internal_call
+                obj = dopvar_autofill(obj);
+            end
         end
         function [obj] = set.Q1(obj,Q1)
             obj.Q1 = Q1;
+            if ~obj.internal_call
+                obj = dopvar_autofill(obj);
+            end
         end
         function [obj] = set.Q2(obj,Q2)
             obj.Q2 = Q2;
+            if ~obj.internal_call
+                obj = dopvar_autofill(obj);
+            end
         end
         function [obj] = set.R(obj,R)
             obj.R = R;
+            if ~obj.internal_call
+                obj = dopvar_autofill(obj);
+            end
         end
         function [d] = get.dimdependent(obj)
             % for consistent dimensions following vectors should have
@@ -135,6 +150,7 @@ classdef (InferiorClasses={?polynomial,?dpvar,?opvar}) dopvar
         end
         function [obj] = set.dim(obj,val)
             obj.dim = val;
+            obj.internal_call=1;
             if isempty(obj.P)
                 obj.P = dpvar(zeros(val(1,:)));
             end
@@ -153,6 +169,10 @@ classdef (InferiorClasses={?polynomial,?dpvar,?opvar}) dopvar
             if isempty(obj.R.R2)
                 obj.R.R2 = dpvar(zeros(val(2,1),val(2,2)));
             end
+            obj.internal_call=0;
+        end
+        function obj = dopvar_autofill(obj)
+            obj.dim = obj.dim;
         end
     end
 end

--- a/PIETOOLS_2021b/opvar/@dopvar/eq.m
+++ b/PIETOOLS_2021b/opvar/@dopvar/eq.m
@@ -44,18 +44,18 @@ if nargin<3
     tol=1e-14;
 end    
 
-if ~isa(P1,'opvar')&&(P1==0) 
+if ~isa(P1,'dopvar')&&(P1==0) 
     opvar P1; P1.I = P2.I; P1.dim = P2.dim;
-elseif ~isa(P2,'opvar')&&(P2==0)
+elseif ~isa(P2,'dopvar')&&(P2==0)
     opvar P2; P2.I = P1.I; P2.dim= P1.dim;
-elseif ~isa(P1,'opvar')|| ~isa(P2,'opvar')
+elseif ~isa(P1,'dopvar')|| ~isa(P2,'dopvar')
     error('To check equality either both values must be opvar objects, or one of them have to be zero');
 end
 
 
 
 if any(P1.dim~=P2.dim)
-    disp('Opvars have different dimensions and hence cannot be equal');
+    disp('Dopvars have different dimensions and hence cannot be equal');
     logval=0;
 end
 
@@ -64,11 +64,31 @@ diff.P = double(diff.P);
 diff.Q1 = polynomial(diff.Q1); diff.Q2 = polynomial(diff.Q2); diff.R.R0 = polynomial(diff.R.R0); 
 diff.R.R1 = polynomial(diff.R.R1); diff.R.R2 = polynomial(diff.R.R2); 
 diff.P(abs(diff.P)<tol)=0;
-diff.Q1.coefficient(abs(diff.Q1.coefficient)<tol)=0;
-diff.Q2.coefficient(abs(diff.Q2.coefficient)<tol)=0;
-diff.R.R0.coefficient(abs(diff.R.R0.coefficient)<tol)=0;
-diff.R.R1.coefficient(abs(diff.R.R1.coefficient)<tol)=0;
-diff.R.R2.coefficient(abs(diff.R.R2.coefficient)<tol)=0;
+if isa(diff.Q1,'dpvar')
+    diff.Q1.coefficient(abs(diff.Q1.coefficient)<tol)=0;
+else
+    diff.Q1(abs(diff.Q1)<tol)=0;
+end
+if isa(diff.Q2,'dpvar')
+    diff.Q2.coefficient(abs(diff.Q2.coefficient)<tol)=0;
+else
+    diff.Q2(abs(diff.Q2)<tol)=0;
+end
+if isa(diff.R.R0,'dpvar')
+    diff.R.R0.coefficient(abs(diff.R.R0.coefficient)<tol)=0;
+else
+    diff.R.R0(abs(diff.R.R0)<tol)=0;
+end
+if isa(diff.R.R1,'dpvar')
+    diff.R.R1.coefficient(abs(diff.R.R1.coefficient)<tol)=0;
+else
+    diff.R.R1(abs(diff.R.R1)<tol)=0;
+end
+if isa(diff.R.R2,'dpvar')
+    diff.R.R2.coefficient(abs(diff.R.R2.coefficient)<tol)=0;
+else
+    diff.R.R2(abs(diff.R.R2)<tol)=0;
+end
 
 
 try

--- a/PIETOOLS_2021b/opvar/@dopvar/horzcat.m
+++ b/PIETOOLS_2021b/opvar/@dopvar/horzcat.m
@@ -58,7 +58,16 @@ else
         b.dim = b.dim;
     end
     
-    
+    dopvar Pcat;
+    if isa(a,'dopvar')
+        Pcat.I = a.I; Pcat.var1 = a.var1; Pcat.var2 = a.var2;
+    elseif isa(b,'dopvar')
+        Pcat.I = b.I; Pcat.var1 = b.var1; Pcat.var2 = b.var2;
+    elseif isa(a,'dopvar')&&isa(b,'dopvar')
+        if any(a.I~=b.I)||(a.var1~=b.var1)||(a.var2~=b.var2)
+            error('Operators being concatenated have different intervals or different independent variables');
+        end
+    end
     
     if ~isa(a,'dopvar')
         if ~isa(b,'dopvar') % both are not dopvar type variables
@@ -67,21 +76,21 @@ else
             if size(a,1)~=b.dim(2,1) 
                 error('Cannot concatentate horizontally. A and B have different output dimensions');
             end 
-            Pcat = b;
+%             Pcat = b;
             Pcat.Q2 = [a b.Q2];
             Pcat.P = [zeros(b.dim(1,1),size(a,2)) b.P];
         elseif ~isa(a,'opvar')&&b.dim(2,1)==0 % a() is from R to R, Note: L2 to R needs to be an opvar
             if size(a,1)~=b.dim(1,1) 
                 error('Cannot concatentate horizontally. A and B have different output dimensions');
             end
-            Pcat = b;
+%             Pcat = b;
             Pcat.P = [a b.P];
             Pcat.Q2 = [zeros(b.dim(2,1),size(a,2)) b.Q2];
         else
         if any(b.dim(:,1)~=a.dim(:,1))
             error('Cannot concatentate horizontally. A and B have different output dimensions');
         end
-        Pcat = b;
+%         Pcat = b;
         fset = {'P', 'Q1', 'Q2'};
 
         for i=fset
@@ -97,21 +106,21 @@ else
             if size(b,1)~=a.dim(2,1) 
                 error('Cannot concatentate horizontally. A and B have different output dimensions');
             end
-            Pcat = a;
+%             Pcat = a;
             Pcat.Q2 = [a.Q2 b];
             Pcat.P = [a.P zeros(a.dim(1,1),size(b,2))];
         elseif ~isa(b,'opvar')&&a.dim(2,1)==0 % b() is from R to R, Note: L2 to R needs to be an opvar
             if size(b,1)~=a.dim(1,1) 
                 error('Cannot concatentate horizontally. A and B have different output dimensions');
             end
-            Pcat = a;
+%             Pcat = a;
             Pcat.P = [a.P b];
             Pcat.Q2 = [a.Q2 zeros(a.dim(2,1),size(b,2))];
         else
         if any(b.dim(:,1)~=a.dim(:,1))
             error('Cannot concatentate horizontally. A and B have different output dimensions');
         end
-        Pcat = a;
+%         Pcat = a;
         fset = {'P', 'Q1', 'Q2'};
 
         for i=fset
@@ -126,7 +135,7 @@ else
         if any(b.dim(:,1)~=a.dim(:,1))
             error('Cannot concatentate horizontally. A and B have different output dimensions');
         end
-        Pcat = a;
+%         Pcat = a;
         fset = {'P', 'Q1', 'Q2'};
 
         for i=fset

--- a/PIETOOLS_2021b/opvar/@dopvar/isvalid.m
+++ b/PIETOOLS_2021b/opvar/@dopvar/isvalid.m
@@ -46,7 +46,7 @@ function [logval, msg] = isvalid(P)
 %
 
 if ~isa(P,'dopvar')
-    error('To check validity input must be opvar object');
+    error('To check validity input must be dopvar object');
 end
 
 dim = P.dim;
@@ -87,9 +87,9 @@ end
 if any(isnan(dim(:)))
     logval=1;
     msg = 'Components have incompatible dimensions';
-elseif ~isa(P.P,'double')
-    logval=2;
-    msg = 'P is not a matrix';
+elseif ~isa(P.P,'double') && (isa(P.P,'dpvar')&&any(P.P.degmat(:)))
+        logval=2;
+        msg = 'P is not a constant dpvar';
 elseif ~isa(Q1,'double')&&~isempty(Q1diff)
     logval=3;
     msg= 'Q1 has pvars different from var1';
@@ -107,6 +107,6 @@ elseif ~isa(R2,'double')&&~isempty(R2diff)
     msg= 'R2 has pvars different from var1 and var2';
 else
     logval=0;
-    msg = 'Valid Opvar';
+    msg = 'Valid Dopvar';
 end
 end

--- a/PIETOOLS_2021b/opvar/@dopvar/mtimes.m
+++ b/PIETOOLS_2021b/opvar/@dopvar/mtimes.m
@@ -59,7 +59,7 @@ if isa(P1,'opvar')||isa(P2,'opvar')
     b=P1.I(2);
     ds = P1.var1;
     dtheta = P1.var2;
-    I = P2.I;
+    I = P1.I;
 
     dopvar Pcomp;
     Pcomp.I = I; Pcomp.var1 = ds; Pcomp.var2 = dtheta;
@@ -74,7 +74,11 @@ if isa(P1,'opvar')||isa(P2,'opvar')
     Pcomp.R.R1 = P1.Q2*subs(P2.Q1,ds,dtheta)+Ptemp.R.R1;
     Pcomp.R.R2 = P1.Q2*subs(P2.Q1,ds,dtheta)+Ptemp.R.R2;
 elseif ~isa(P2,'dopvar') %multiplication of operator times matrix
-    Pcomp = P1;
+    ds = P1.var1;
+    dtheta = P1.var2;
+    I = P1.I;
+    dopvar Pcomp;
+    Pcomp.I = I; Pcomp.var1 = ds; Pcomp.var2 = dtheta;
     if all(size(P2)==[1,1]) %scalar multiplication
         Pcomp.P = P2*P1.P;
         Pcomp.Q1 = P2*P1.Q1;
@@ -101,7 +105,11 @@ elseif ~isa(P2,'dopvar') %multiplication of operator times matrix
         Pcomp.R.R2 = P1.R.R2*P2p;
     end
 else %multiplication of matrix times the operator
-    Pcomp = P2;
+    ds = P2.var1;
+    dtheta = P2.var2;
+    I = P2.I;
+    dopvar Pcomp;
+    Pcomp.I = I; Pcomp.var1 = ds; Pcomp.var2 = dtheta;
     if all(size(P1)==[1,1]) %scalar times operator
         Pcomp.P = P1*P2.P;
         Pcomp.Q1 = P1*P2.Q1;

--- a/PIETOOLS_2021b/opvar/@dopvar/plus.m
+++ b/PIETOOLS_2021b/opvar/@dopvar/plus.m
@@ -1,10 +1,10 @@
-function [Pplus] = plus(P1,P2) 
+function [Pplus] = plus(P1,P2)
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 % [Pplus] = plus(P1,P2) performs addition of two operators P: R^p x L2^q to R^m x L2^n
-% 
+%
 % INPUT
 % P1, P2: dopvar class objects
-% 
+%
 % OUTPUT
 % Pplus: returns P1+P2
 %
@@ -38,21 +38,30 @@ function [Pplus] = plus(P1,P2)
 %
 % Adjusted to assure sum with opvar returns dopvar, DJ 12/30/2021
 
-
+dopvar Pplus;
+if isa(P1,'dopvar')
+    Pplus.I = P1.I; Pplus.var1 = P1.var1; Pplus.var2 = P1.var2; Pplus.dim = P1.dim;
+elseif isa(P2,'dopvar')
+    Pplus.I = P2.I; Pplus.var1 = P2.var1; Pplus.var2 = P2.var2; Pplus.dim = P2.dim;
+elseif isa(P1,'dopvar')&&isa(P2,'dopvar')
+    if any(P1.I~=P2.I)||(P1.var1~=P2.var1)||(P1.var2~=P2.var2)
+        error('Operators being added have different intervals or different independent variables');
+    end
+end
 
 if (isa(P1,'polynomial')||isa(P1,'double')||isa(P1,'dpvar'))&&all(size(P1)==[1,1])&&all(P2.dim(:,1)==P2.dim(:,2))
-    Pplus = P2;
+%     Pplus = P2;
     Pplus.P=Pplus.P+P1*eye(P2.dim(1,2)); Pplus.R.R0 = Pplus.R.R0+P1*eye(P2.dim(2,2));
 elseif (isa(P2,'polynomial')||isa(P2,'double')||isa(P2,'double'))&&all(size(P2)==[1,1])&&all(P1.dim(:,1)==P1.dim(:,2))
-    Pplus = P1;
+%     Pplus = P1;
     Pplus.P=Pplus.P+P2*eye(P1.dim(1,2)); Pplus.R.R0 = Pplus.R.R0+P2*eye(P1.dim(2,2));
 elseif ~isa(P1,'dopvar')&& ~isa(P1,'opvar')
     P2dim = P2.dim;
     if all(P2dim(2,:)==[0,0])&&all(size(P1)==P2dim(1,:))
-        Pplus = P2;
+%         Pplus = P2;
         Pplus.P = P1+Pplus.P;
     elseif all(P2dim(1,:)==[0,0])&&all(size(P1)==P2dim(2,:))
-        Pplus = P2;
+%         Pplus = P2;
         Pplus.R.R0 = P1+Pplus.R.R0;
     end
 elseif ~isa(P2,'dopvar')&&~isa(P2,'opvar')
@@ -72,11 +81,11 @@ else %both are PI operators
         error('Operators act on different intervals and cannot be added');
     end
     %Create a holder variable for the resultant operator
-    if isa(P1,'dopvar')     % DJ, 12/30/2021
-        Pplus = P1;
-    else
-        Pplus = P2;
-    end
+%     if isa(P1,'dopvar')     % DJ, 12/30/2021
+%         Pplus = P1;
+%     else
+%         Pplus = P2;
+%     end
     
     
     fset = {'P', 'Q1', 'Q2'};

--- a/PIETOOLS_2021b/opvar/@dopvar/vertcat.m
+++ b/PIETOOLS_2021b/opvar/@dopvar/vertcat.m
@@ -53,6 +53,17 @@ else
         b.dim = b.dim;
     end
     
+    dopvar Pcat;
+    if isa(a,'dopvar')
+        Pcat.I = a.I; Pcat.var1 = a.var1; Pcat.var2 = a.var2;
+    elseif isa(b,'dopvar')
+        Pcat.I = b.I; Pcat.var1 = b.var1; Pcat.var2 = b.var2;
+    elseif isa(a,'dopvar')&&isa(b,'dopvar')
+        if any(a.I~=b.I)||(a.var1~=b.var1)||(a.var2~=b.var2)
+            error('Operators being concatenated have different intervals or different independent variables');
+        end
+    end
+    
     if ~isa(a,'dopvar')
         if ~isa(b,'dopvar')
             Pcat = [a;b];
@@ -61,7 +72,7 @@ else
             if ~isa(a,'opvar') && size(a,2)~=sum(bdim(:,2)) % DJ 09/29/2021
                 error("Cannot concatentate vertically. A and B have different input dimensions");
             end
-            Pcat = b;
+%             Pcat = b;
             if bdim(2,2) ==0 && ~isa(a,'opvar')
                 Pcat.P = [a; b.P]; % a() is from R to R
                 Pcat.Q1 =[zeros(size(a,1),b.dim(2,2)); b.Q1];
@@ -72,9 +83,9 @@ else
                 Pcat.R.R2 = [zeros(size(a)); b.R.R2];
             else %find if such a operation is valid is any useful scenario and implement it
                 if any(b.dim(:,2)~=a.dim(:,2))
-            error("Cannot concatentate vertically. A and B have different input dimensions");
-        end
-        Pcat = b;
+                    error("Cannot concatentate vertically. A and B have different input dimensions");
+                end
+%         Pcat = b;
         fset = {'P', 'Q1', 'Q2'};
         for i=fset
             Pcat.(i{:}) = [a.(i{:}); b.(i{:})];
@@ -90,7 +101,7 @@ else
         if ~isa(b,'opvar') && size(b,2)~=sum(adim(:,2)) % DJ 09/29/2021
             error("Cannot concatentate vertically. A and B have different input dimensions");
         end
-        Pcat = a;
+%         Pcat = a;
         if adim(2,2) ==0&& ~isa(b,'opvar')
             Pcat.P = [a.P; b]; % b() is from R to R
             Pcat.Q1 = [a.Q1; zeros(size(b,1),a.dim(2,2))];
@@ -101,9 +112,9 @@ else
             Pcat.R.R2 = [a.R.R2; zeros(size(b))];
         else %find if such a operation is valid is any useful scenario and implement it
             if any(b.dim(:,2)~=a.dim(:,2))
-            error("Cannot concatentate vertically. A and B have different input dimensions");
-        end
-        Pcat = a;
+                error("Cannot concatentate vertically. A and B have different input dimensions");
+            end
+%         Pcat = a;
         fset = {'P', 'Q1', 'Q2'};
         for i=fset
             Pcat.(i{:}) = [a.(i{:}); b.(i{:})];
@@ -117,7 +128,7 @@ else
         if any(b.dim(:,2)~=a.dim(:,2))
             error("Cannot concatentate vertically. A and B have different input dimensions");
         end
-        Pcat = a;
+%         Pcat = a;
         fset = {'P', 'Q1', 'Q2'};
         for i=fset
             Pcat.(i{:}) = [a.(i{:}); b.(i{:})];

--- a/PIETOOLS_2021b/opvar/@opvar/ctranspose.m
+++ b/PIETOOLS_2021b/opvar/@opvar/ctranspose.m
@@ -1,4 +1,4 @@
-function [P] = ctranspose(P)
+function [Pt] = ctranspose(P)
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 % P] = ctranspose(P) transposes an operator P: R^p x L2^q to R^m x L2^n
 % Date: 6/13/19
@@ -45,12 +45,12 @@ if ~isa(P,'opvar')
     error('Input must be an opvar variable.');
 end
 
-P.P = P.P';
-Q2 = P.Q2;
-P.Q2 = P.Q1';
-P.Q1 = Q2';
-P.R.R0 = P.R.R0';
-R2 = P.R.R2;
-P.R.R2 = var_swap(P.R.R1',P.var1, P.var2);
-P.R.R1 = var_swap(R2',P.var1, P.var2);
+opvar Pt; Pt.I = P.I; Pt.var1= P.var1; Pt.var2 = P.var2;
+
+Pt.P = P.P';
+Pt.Q2 = P.Q1';
+Pt.Q1 = P.Q2';
+Pt.R.R0 = P.R.R0';
+Pt.R.R2 = var_swap(P.R.R1',P.var1, P.var2);
+Pt.R.R1 = var_swap(P.R.R2',P.var1, P.var2);
 end

--- a/PIETOOLS_2021b/opvar/@opvar/eq.m
+++ b/PIETOOLS_2021b/opvar/@opvar/eq.m
@@ -63,12 +63,33 @@ diff = P1-P2;
 diff.P = double(diff.P);
 diff.Q1 = polynomial(diff.Q1); diff.Q2 = polynomial(diff.Q2); diff.R.R0 = polynomial(diff.R.R0); 
 diff.R.R1 = polynomial(diff.R.R1); diff.R.R2 = polynomial(diff.R.R2); 
+
 diff.P(abs(diff.P)<tol)=0;
-diff.Q1.coefficient(abs(diff.Q1.coefficient)<tol)=0;
-diff.Q2.coefficient(abs(diff.Q2.coefficient)<tol)=0;
-diff.R.R0.coefficient(abs(diff.R.R0.coefficient)<tol)=0;
-diff.R.R1.coefficient(abs(diff.R.R1.coefficient)<tol)=0;
-diff.R.R2.coefficient(abs(diff.R.R2.coefficient)<tol)=0;
+if isa(diff.Q1,'polynomial')
+    diff.Q1.coefficient(abs(diff.Q1.coefficient)<tol)=0;
+else
+    diff.Q1(abs(diff.Q1)<tol)=0;
+end
+if isa(diff.Q2,'polynomial')
+    diff.Q2.coefficient(abs(diff.Q2.coefficient)<tol)=0;
+else
+    diff.Q2(abs(diff.Q2)<tol)=0;
+end
+if isa(diff.R.R0,'polynomial')
+    diff.R.R0.coefficient(abs(diff.R.R0.coefficient)<tol)=0;
+else
+    diff.R.R0(abs(diff.R.R0)<tol)=0;
+end
+if isa(diff.R.R1,'polynomial')
+    diff.R.R1.coefficient(abs(diff.R.R1.coefficient)<tol)=0;
+else
+    diff.R.R1(abs(diff.R.R1)<tol)=0;
+end
+if isa(diff.R.R2,'polynomial')
+    diff.R.R2.coefficient(abs(diff.R.R2.coefficient)<tol)=0;
+else
+    diff.R.R2(abs(diff.R.R2)<tol)=0;
+end
 
 
 try

--- a/PIETOOLS_2021b/opvar/@opvar/horzcat.m
+++ b/PIETOOLS_2021b/opvar/@opvar/horzcat.m
@@ -49,6 +49,16 @@ else
     a = varargin{1};
     b = varargin{2};
     
+    opvar Pcat;
+    if isa(a,'opvar')
+        Pcat.I = a.I; Pcat.var1 = a.var1; Pcat.var2 = a.var2;
+    elseif isa(b,'opvar')
+        Pcat.I = b.I; Pcat.var1 = b.var1; Pcat.var2 = b.var2;
+    elseif isa(a,'opvar')&&isa(b,'opvar')
+        if any(a.I~=b.I)||(a.var1~=b.var1)||(a.var2~=b.var2)
+            error('Operators being concatenated have different intervals or different independent variables');
+        end
+    end
     if isa(a,'opvar') % correction to make components have consistent dimensions 8/27-ss
         a.dim = a.dim;
     end
@@ -72,14 +82,14 @@ else
             if size(a,1)~=b.dim(2,1) 
                 error('Cannot concatentate horizontally. A and B have different output dimensions');
             end 
-            Pcat = b;
+%             Pcat = b;
             Pcat.Q2 = [a b.Q2];
             Pcat.P = [zeros(b.dim(1,1),size(a,2)) b.P];
         elseif b.dim(2,1)==0 % a() is from R to R, Note: L2 to R needs to be an opvar
             if size(a,1)~=b.dim(1,1) 
                 error('Cannot concatentate horizontally. A and B have different output dimensions');
             end
-            Pcat = b;
+%             Pcat = b;
             Pcat.P = [a b.P];
             Pcat.Q2 = [zeros(b.dim(2,1),size(a,2)) b.Q2];
         else %find if such an operation is valid is any useful scenario and implement it
@@ -90,14 +100,14 @@ else
             if size(b,1)~=a.dim(2,1) 
                 error('Cannot concatentate horizontally. A and B have different output dimensions');
             end
-            Pcat = a;
+%             Pcat = a;
             Pcat.Q2 = [a.Q2 b];
             Pcat.P = [a.P zeros(a.dim(1,1),size(b,2))];
         elseif a.dim(2,1)==0 % b() is from R to R, Note: L2 to R needs to be an opvar
             if size(b,1)~=a.dim(1,1) 
                 error('Cannot concatentate horizontally. A and B have different output dimensions');
             end
-            Pcat = a;
+%             Pcat = a;
             Pcat.P = [a.P b];
             Pcat.Q2 = [a.Q2 zeros(a.dim(2,1),size(b,2))];
         else %find if such a operation is valid is any useful scenario and implement it
@@ -107,7 +117,7 @@ else
         if any(b.dim(:,1)~=a.dim(:,1))
             error('Cannot concatentate horizontally. A and B have different output dimensions');
         end
-        Pcat = a;
+%         Pcat = a;
         fset = {'P', 'Q1', 'Q2'};
 
         for i=fset

--- a/PIETOOLS_2021b/opvar/@opvar/mtimes.m
+++ b/PIETOOLS_2021b/opvar/@opvar/mtimes.m
@@ -60,9 +60,9 @@ a=P1.I(1);
 b=P1.I(2);
 ds = P1.var1;
 dtheta = P1.var2;
-I = P2.I;
+I = P1.I;
 
-Pcomp = P2;
+opvar Pcomp; Pcomp.I = I; Pcomp.var1 = ds; Pcomp.var2 = dtheta;
 
 Pcomp.P = P1.P*P2.P + int(P1.Q1*P2.Q2,ds,a,b);
 Pcomp.Q1 = P1.P*P2.Q1 + P1.Q1*P2.R.R0+ int(var_swap(P1.Q1*P2.R.R1,ds,dtheta),dtheta,ds,b)+...
@@ -75,7 +75,10 @@ Pcomp.R.R1 = P1.Q2*subs(P2.Q1,ds,dtheta)+Ptemp.R.R1;
 Pcomp.R.R2 = P1.Q2*subs(P2.Q1,ds,dtheta)+Ptemp.R.R2;
 
 elseif ~isa(P2,'opvar') %multiplication of operator times matrix
-    Pcomp = P1;
+    ds = P2.var1;
+    dtheta = P2.var2;
+    I = P2.I;
+    opvar Pcomp; Pcomp.I = I; Pcomp.var1 = ds; Pcomp.var2 = dtheta;
     if all(size(P2)==[1,1]) %scalar multiplication
         Pcomp.P = P2*P1.P;
         Pcomp.Q1 = P2*P1.Q1;
@@ -105,7 +108,10 @@ elseif ~isa(P2,'opvar') %multiplication of operator times matrix
         Pcomp = opvar2dopvar(Pcomp);
     end
 else %multiplication of matrix times the operator
-    Pcomp = P2;
+    ds = P2.var1;
+    dtheta = P2.var2;
+    I = P2.I;
+    opvar Pcomp; Pcomp.I = I; Pcomp.var1 = ds; Pcomp.var2 = dtheta;
     if all(size(P1)==[1,1]) %scalar times operator
         Pcomp.P = P1*P2.P;
         Pcomp.Q1 = P1*P2.Q1;

--- a/PIETOOLS_2021b/opvar/@opvar/opvar.m
+++ b/PIETOOLS_2021b/opvar/@opvar/opvar.m
@@ -55,9 +55,12 @@ classdef (InferiorClasses={?polynomial,?dpvar}) opvar
         Q2 = polynomial([]);
         R = struct('R0',polynomial([]),'R1',polynomial([]),'R2',polynomial([]));
         I(1,2) double = [0,1];
-        var1 = pvar('s');
-        var2 = pvar('theta');
-        dim = [0 0; 0 0];
+        var1 polynomial = pvar('s');
+        var2 polynomial = pvar('theta');
+        dim(2,2) double = [0 0; 0 0];
+    end
+    properties (Hidden)
+        internal_call = 0;
     end
     properties (Dependent)
         dimdependent;
@@ -76,15 +79,27 @@ classdef (InferiorClasses={?polynomial,?dpvar}) opvar
         end
         function [obj] = set.P(obj,P) 
             obj.P = P;
+            if ~obj.internal_call
+                obj = opvar_autofill(obj);
+            end
         end
         function [obj] = set.Q1(obj,Q1)
             obj.Q1 = Q1;
+            if ~obj.internal_call
+                obj = opvar_autofill(obj);
+            end
         end
         function [obj] = set.Q2(obj,Q2)
             obj.Q2 = Q2;
+            if ~obj.internal_call
+                obj = opvar_autofill(obj);
+            end
         end
         function [obj] = set.R(obj,R)
             obj.R = R;
+            if ~obj.internal_call
+                obj = opvar_autofill(obj);
+            end
         end
         function [d] = get.dimdependent(obj)
             % for consistent dimensions following vectors should have
@@ -137,6 +152,7 @@ classdef (InferiorClasses={?polynomial,?dpvar}) opvar
         end
         function [obj] = set.dim(obj,val)
             obj.dim = val;
+            obj.internal_call=1;
             if isempty(obj.P)
                 obj.P = zeros(val(1,:));
             end
@@ -155,6 +171,10 @@ classdef (InferiorClasses={?polynomial,?dpvar}) opvar
             if isempty(obj.R.R2)
                 obj.R.R2 = zeros(val(2,1),val(2,2));
             end
+            obj.internal_call=0;
+        end
+        function obj = opvar_autofill(obj)
+            obj.dim = obj.dim;
         end
     end
 end

--- a/PIETOOLS_2021b/opvar/@opvar/plus.m
+++ b/PIETOOLS_2021b/opvar/@opvar/plus.m
@@ -52,28 +52,39 @@ elseif isa(P2,'dpvar')
     return
 end
 
+opvar Pplus; 
+if isa(P1,'opvar')
+    Pplus.I = P1.I; Pplus.var1 = P1.var1; Pplus.var2 = P1.var2; Pplus.dim = P1.dim;
+elseif isa(P2,'opvar')
+    Pplus.I = P2.I; Pplus.var1 = P2.var1; Pplus.var2 = P2.var2; Pplus.dim = P2.dim;
+elseif isa(P1,'opvar')&&isa(P2,'opvar')
+    if any(P1.I~=P2.I)||(P1.var1~=P2.var1)||(P1.var2~=P2.var2)
+        error('Operators being added have different intervals or different independent variables');
+    end
+end
+
 if (isa(P1,'polynomial')||isa(P1,'double'))&&all(size(P1)==[1,1])&&all(P2.dim(:,1)==P2.dim(:,2))
-    Pplus = P2;
+%     Pplus = P2;
     Pplus.P=Pplus.P+P1*eye(P2.dim(1,2)); Pplus.R.R0 = Pplus.R.R0+P1*eye(P2.dim(2,2));
 elseif (isa(P2,'polynomial')||isa(P2,'double'))&&all(size(P2)==[1,1])&&all(P1.dim(:,1)==P1.dim(:,2))
-    Pplus = P1;
+%     Pplus = P1;
     Pplus.P=Pplus.P+P2*eye(P1.dim(1,2)); Pplus.R.R0 = Pplus.R.R0+P2*eye(P1.dim(2,2));
 elseif ~isa(P1,'opvar') 
     P2dim = P2.dim;
     if all(P2dim(2,:)==[0,0])&&all(size(P1)==P2dim(1,:))
-        Pplus = P2;
+%         Pplus = P2;
         Pplus.P = P1+Pplus.P;
     elseif all(P2dim(1,:)==[0,0])&&all(size(P1)==P2dim(2,:))
-        Pplus = P2;
+%         Pplus = P2;
         Pplus.R.R0 = P1+Pplus.R.R0;
     end
 elseif ~isa(P2,'opvar')
     P1dim = P1.dim;
     if all(P1dim(2,:)==[0,0])&&all(size(P2)==P1dim(1,:))
-        Pplus = P1;
+%         Pplus = P1;
         Pplus.P = P2+Pplus.P;
     elseif all(P1dim(1,:)==[0,0])&&all(size(P2)==P1dim(2,:))
-        Pplus = P1;
+%         Pplus = P1;
         Pplus.R.R0 = P2+Pplus.R.R0;
     end
 else %both are PI operators
@@ -84,7 +95,7 @@ else %both are PI operators
         error('Operators act on different intervals and cannot be added');
     end
     %Create a holder variable for the resultant operator
-    Pplus = P1;
+%     Pplus = P1;
     
     
     fset = {'P', 'Q1', 'Q2'};

--- a/PIETOOLS_2021b/opvar/@opvar/vertcat.m
+++ b/PIETOOLS_2021b/opvar/@opvar/vertcat.m
@@ -49,6 +49,16 @@ else
     a = varargin{1};
     b = varargin{2};
     
+    opvar Pcat;
+    if isa(a,'opvar')
+        Pcat.I = a.I; Pcat.var1 = a.var1; Pcat.var2 = a.var2;
+    elseif isa(b,'opvar')
+        Pcat.I = b.I; Pcat.var1 = b.var1; Pcat.var2 = b.var2;
+    elseif isa(a,'opvar')&&isa(b,'opvar')
+        if any(a.I~=b.I)||(a.var1~=b.var1)||(a.var2~=b.var2)
+            error('Operators being concatenated have different intervals or different independent variables');
+        end
+    end
     if isa(a,'opvar') % correction to make components have consistent dimensions 8/27-ss
         a.dim = a.dim;
     end
@@ -73,7 +83,7 @@ else
             if size(a,2)~=sum(bdim(:,2))
                 error("Cannot concatentate vertically. A and B have different input dimensions");
             end
-            Pcat = b;
+%             Pcat = b;
             if bdim(2,2) ==0
                 Pcat.P = [a; b.P]; % a() is from R to R
                 Pcat.Q1 =[zeros(size(a,1),b.dim(2,2)); b.Q1];
@@ -91,7 +101,7 @@ else
         if size(b,2)~=sum(adim(:,2))
             error("Cannot concatentate vertically. A and B have different input dimensions");
         end
-        Pcat = a;
+%         Pcat = a;
         if adim(2,2) ==0
             Pcat.P = [a.P; b]; % b() is from R to R
             Pcat.Q1 = [a.Q1; zeros(size(b,1),a.dim(2,2))];
@@ -107,7 +117,7 @@ else
         if any(b.dim(:,2)~=a.dim(:,2))
             error("Cannot concatentate vertically. A and B have different input dimensions");
         end
-        Pcat = a;
+%         Pcat = a;
         fset = {'P', 'Q1', 'Q2'};
         for i=fset
             Pcat.(i{:}) = [a.(i{:}); b.(i{:})];

--- a/PIETOOLS_2021b/opvar/getsol_lpivar.m
+++ b/PIETOOLS_2021b/opvar/getsol_lpivar.m
@@ -1,4 +1,4 @@
-function P = getsol_lpivar(sos,P)
+function Psol = getsol_lpivar(sos,P)
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 % P = getsol_lpivar(sos,P) returns the solution for each component of P, 
 % after solving the sos program prog.
@@ -40,15 +40,17 @@ function P = getsol_lpivar(sos,P)
 %
 % Initial coding MMP, SS, DJ  - 09/26/2021
 
+opvar Psol; Psol.I = P.I; Psol.var1 = P.var1; Psol.var2 = P.var2;
+
 for i = {'P','Q1','Q2'}
     if ~isempty(P.(i{:}))
-        P.(i{:}) = sosgetsol(sos, P.(i{:}));
+        Psol.(i{:}) = sosgetsol(sos, P.(i{:}));
     end
 end
 for i = {'R0','R1','R2'}
     if ~isempty(P.R.(i{:}))
-        P.R.(i{:}) = sosgetsol(sos, P.R.(i{:}));
+        Psol.R.(i{:}) = sosgetsol(sos, P.R.(i{:}));
     end
 end
-P.P = double(P.P);
+Psol.P = double(Psol.P);
 end


### PR DESCRIPTION
Added an new mechanism where after every property set call dimensions of the opvar/dopvar are recalculated and missing parameters are reassigned to zeros of appropriate dimensions.

a) first added an internal flag property - obj.internal_call
b) if a property is changed from outside, the flag is zero and all the other missing properties are auto-initialized using opvar_autofill() method
c) if a property is changed from within the reinitialization routine (set.dim() method which is called by opvar_autofill() method), the flag is set to one to avoid infinite recursion 