### PR TITLE
Added support for infinite dimensional outputs and inputs

### DIFF
--- a/PIETOOLS/executives/PIETOOLS_Hinf_gain.m
+++ b/PIETOOLS/executives/PIETOOLS_Hinf_gain.m
@@ -129,10 +129,10 @@ prog = sossetobj(prog, gam); %this minimizes gamma, comment for feasibility test
 % function candidate
 disp('- Declaring Positive Lyapunov Operator variable using specified options...');
 
-[prog, P1op] = poslpivar(prog, [nx1 ,nx2],X,dd1,options1);
+[prog, P1op] = poslpivar(prog, PIE.T.dim(:,1),X,dd1,options1);
 
 if override1~=1
-    [prog, P2op] = poslpivar(prog, [nx1 ,nx2],X,dd12,options12);
+    [prog, P2op] = poslpivar(prog, PIE.T.dim(:,1),X,dd12,options12);
     Pop=P1op+P2op;
 else
     Pop=P1op;
@@ -146,11 +146,18 @@ end
 %          D         -gamma*I C
 %          T'*P*B      C'       T'*P*A+A'*P*T]
 
+% adding adjustment for infinite-dimensional I/O
+opvar Iw Iz;
+Iw.dim = [PIE.B1.dim(:,2),PIE.B1.dim(:,2)];
+Iz.dim = [PIE.C1.dim(:,1),PIE.C1.dim(:,1)];
+Iw.P = eye(size(Iw.P)); Iz.P = eye(size(Iz.P));
+Iw.R.R0 = eye(size(Iw.R.R0)); Iz.R.R0 = eye(size(Iz.R.R0));
+
 
 disp('- Constructing the Negativity Constraint...');
 
-Dop = [-gam*eye(nw)+TB1op'*(Pop*B1op)+(Pop*B1op)'*TB1op     D11op'             (Pop*B1op)'*Top+TB1op'*(Pop*Aop);
-        D11op                                              -gam*eye(nz)        C1op;
+Dop = [-gam*Iw+TB1op'*(Pop*B1op)+(Pop*B1op)'*TB1op     D11op'             (Pop*B1op)'*Top+TB1op'*(Pop*Aop);
+        D11op                                              -gam*Iz        C1op;
         Top'*(Pop*B1op)+(Pop*Aop)'*TB1op                    C1op'              (Pop*Aop)'*Top+Top'*(Pop*Aop)];
     
     
@@ -165,10 +172,10 @@ if sosineq_on
     prog = lpi_ineq(prog,-Dop,opts);
 else
     disp('  - Using an Equality constraint...');
-    [prog, De1op] = poslpivar(prog, [nw+nz+nx1, nx2],X,dd2,options2);
+    [prog, De1op] = poslpivar(prog, Iw.dim(:,1)+Iz.dim(:,1)+PIE.T.dim(:,1),X,dd2,options2);
     
     if override2~=1
-        [prog, De2op] = poslpivar(prog,[nw+nz+nx1, nx2],X, dd3,options3);
+        [prog, De2op] = poslpivar(prog,Iw.dim(:,1)+Iz.dim(:,1)+PIE.T.dim(:,1),X, dd3,options3);
         Deop=De1op+De2op;
     else
         Deop=De1op;

--- a/PIETOOLS/executives/PIETOOLS_stability.m
+++ b/PIETOOLS/executives/PIETOOLS_stability.m
@@ -101,10 +101,10 @@ nx2=PIE.A.dim(2,1);                % retrieve the number of distributed states f
 % function candidate
 disp('- Parameterizing Positive Lyapunov Operator using specified options...');
 
-[prog, P1op] = poslpivar(prog, [nx1 ,nx2],X,dd1,options1);
+[prog, P1op] = poslpivar(prog, PIE.T.dim(:,1),X,dd1,options1);
 
 if override1~=1
-    [prog, P2op] = poslpivar(prog, [nx1 ,nx2],X,dd12,options12);
+    [prog, P2op] = poslpivar(prog, PIE.T.dim(:,1),X,dd12,options12);
     Pop=P1op+P2op;
 else
     Pop=P1op;
@@ -140,10 +140,10 @@ if sosineq_on
 else
     disp('  - Using an Equality constraint...');
     
-    [prog, De1op] = poslpivar(prog, [nx1, nx2],X,dd2,options2);
+    [prog, De1op] = poslpivar(prog, PIE.T.dim(:,1),X,dd2,options2);
     
     if override2~=1
-        [prog, De2op] = poslpivar(prog,[nx1, nx2],X, dd3,options3);
+        [prog, De2op] = poslpivar(prog,PIE.T.dim(:,1),X, dd3,options3);
         Deop=De1op+De2op;
     else
         Deop=De1op;

--- a/PIETOOLS/executives/PIETOOLS_stability_dual.m
+++ b/PIETOOLS/executives/PIETOOLS_stability_dual.m
@@ -108,10 +108,10 @@ nx2=Aop.dim(2,1);                % retrieve the number of distributed states fro
 % function candidate
 disp('- Parameterizing Positive Lyapunov Operator using specified options...');
 
-[prog, P1op] = poslpivar(prog, [nx1 ,nx2],X,dd1,options1);
+[prog, P1op] = poslpivar(prog, PIE.T.dim(:,1),X,dd1,options1);
 
 if override1~=1
-    [prog, P2op] = poslpivar(prog, [nx1 ,nx2],X,dd12,options12);
+    [prog, P2op] = poslpivar(prog, PIE.T.dim(:,1),X,dd12,options12);
     Pop=P1op+P2op;
 else
     Pop=P1op;
@@ -148,10 +148,10 @@ if sosineq_on
 else
     disp('  - Using an Equality constraint...');
 
-    [prog, De1op] = poslpivar(prog, [nx1, nx2],X,dd2,options2);
+    [prog, De1op] = poslpivar(prog, PIE.T.dim(:,1),X,dd2,options2);
     
     if override2~=1
-        [prog, De2op] = poslpivar(prog,[nx1, nx2],X, dd3,options3);
+        [prog, De2op] = poslpivar(prog,PIE.T.dim(:,1),X, dd3,options3);
         Deop=De1op+De2op;
     else
         Deop=De1op;

--- a/PIETOOLS/parser/@sys/convert.m
+++ b/PIETOOLS/parser/@sys/convert.m
@@ -34,7 +34,7 @@ function [out,params] = convert(obj,convertTo)
 % authorship, and a brief description of modifications
 arguments
     obj;
-    convertTo {mustBeMember(convertTo,{'pie','ddf'})} = '';
+    convertTo {mustBeMember(convertTo,{'pie','ddf'})} = 'pie';
 end
 
 if strcmp(convertTo, 'pie')


### PR DESCRIPTION
Modified the LPI executive files such that the PI operators Bi, Ci, and Dij can now map to and from infinite-dimensional (R x L2)-spaces.

**Note:**

- Parser, initializer, and converter for 1D PDEs do not support infinite-dimensional input-outputs yet
- However, parameters of _PIE.(Bi/Ci/Dij)_ opvars can be manually modified to change inputs and outputs to infinite-dimensional signals
- Standard settings in _lpisettings()_ are such that _Deop_ and _De2op_ always exclude the _R0_ parameter from the optimization problem. However, infinite-dimensional I/O would need an _R0_ parameter, and hence _settings_ object must be modified manually after loading preset settings. For e.g.,
`st = lpisettings('heavy');
st.options2.exclude = [0 0 0 0];
st.options3.exclude = [0 0 0 0];`

A sample code to show how this works currently:
`pvar s t theta;
x=state('pde');
z = state('out');
w = state('in');
pde = sys();
pde = addequation(pde,[diff(x,t)==diff(x,s,2)+w;subs(x,s,0)==0;subs(x,s,1)==0;z==subs(diff(x,s),s,1)]);
pie = convert(pde,'pie');
PIE = pie.params;
%currently outputs are finite dimensional. Lets change z = x(t,s) manually
opvar C1 D11; 
C1.dim = [0 0; 1 1]; D11.dim = [0 1; 1 0]; 
C1.R.R0 = 1; 
PIE.C1 = C1; PIE.D11 = D11;
st = lpisettings('heavy');
st.options2.exclude = [0 0 0 0];
st.options3.exclude = [0 0 0 0];
[prog,P,gam] = lpisolve(PIE,st,'l2gain');`

Running tests on other example library files did not produce any errors. 

Also changed second argument of _sys/convert()_ function to 'pie'

Pending 



- [ ] Add support for infinite-dimensional I/O in Parser, initializer, and converter for 1D PDEs
- [ ] Modify settings in _lpisettings()_ to allow infinie-dimensional I/O