### PR TITLE
Update lpi_eq functions to exploit symmetry.

### DIFF
--- a/PIETOOLS/executives/2D/PIETOOLS_H2_norm_2D_c.m
+++ b/PIETOOLS/executives/2D/PIETOOLS_H2_norm_2D_c.m
@@ -153,7 +153,7 @@ function [prog,Wc, gam] = PIETOOLS_H2_norm_2D_c(PIE, settings,options)
     
         end
 
-        prog = lpi_eq_2d(prog,Deop+Dop); %Dop=-Deop
+        prog = lpi_eq_2d(prog,Deop+Dop,'symmetric'); %Dop=-Deop
      end
     
     tempObj = C1op*Wop*C1op';

--- a/PIETOOLS/executives/2D/PIETOOLS_H2_norm_2D_o.m
+++ b/PIETOOLS/executives/2D/PIETOOLS_H2_norm_2D_o.m
@@ -153,7 +153,7 @@ function [prog,Wo, gam] = PIETOOLS_H2_norm_2D_o(PIE, settings,options)
     
         end
 
-        prog = lpi_eq_2d(prog,Deop+Dop); %Dop=-Deop
+        prog = lpi_eq_2d(prog,Deop+Dop,'symmetric'); %Dop=-Deop
      end
     
     tempObj = B1op'*Wop*B1op;

--- a/PIETOOLS/executives/2D/PIETOOLS_Hinf_gain_2D.m
+++ b/PIETOOLS/executives/2D/PIETOOLS_Hinf_gain_2D.m
@@ -307,7 +307,7 @@ else
     end
     
     % Enforce the equality constraint.
-    prog = lpi_eq_2d(prog,Qeop+Qop);
+    prog = lpi_eq_2d(prog,Qeop+Qop,'symmetric');
 end
 
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%

--- a/PIETOOLS/executives/2D/PIETOOLS_Hinf_gain_dual_2D.m
+++ b/PIETOOLS/executives/2D/PIETOOLS_Hinf_gain_dual_2D.m
@@ -281,7 +281,7 @@ else
     end
     
     % Enforce the equality constraint Qop=-Qeop.
-    prog = lpi_eq_2d(prog,Qeop+Qop);
+    prog = lpi_eq_2d(prog,Qeop+Qop,'symmetric');
 end
 
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%

--- a/PIETOOLS/executives/2D/PIETOOLS_stability_2D.m
+++ b/PIETOOLS/executives/2D/PIETOOLS_stability_2D.m
@@ -221,7 +221,7 @@ else
     end
     
     % Enforce the equality constraint Qop=-Qeop.
-    prog = lpi_eq_2d(prog,Qeop+Qop);
+    prog = lpi_eq_2d(prog,Qeop+Qop,'symmetric');
 end
 
 

--- a/PIETOOLS/executives/2D/PIETOOLS_stability_dual_2D.m
+++ b/PIETOOLS/executives/2D/PIETOOLS_stability_dual_2D.m
@@ -223,7 +223,7 @@ else
     end
     
     % Enforce the equality constraint Qop=-Qeop.
-    prog = lpi_eq_2d(prog,Qeop+Qop);
+    prog = lpi_eq_2d(prog,Qeop+Qop,'symmetric');
 end
 
 

--- a/PIETOOLS/executives/PIETOOLS_H2_norm_c.m
+++ b/PIETOOLS/executives/PIETOOLS_H2_norm_c.m
@@ -151,7 +151,7 @@ disp('Requires creating H2 norm script for 2D systems')
         else
             Deop=De1op;
         end
-        prog = lpi_eq(prog,Deop+Dop); %Dop=-Deop
+        prog = lpi_eq(prog,Deop+Dop,'symmetric'); %Dop=-Deop
     end
     
     tempObj = C1op*Wop*C1op';

--- a/PIETOOLS/executives/PIETOOLS_H2_norm_o.m
+++ b/PIETOOLS/executives/PIETOOLS_H2_norm_o.m
@@ -150,7 +150,7 @@ function [prog,Wo, gam]= PIETOOLS_H2_norm_o(PIE, settings,varargin)
         else
             Deop=De1op;
         end
-        prog = lpi_eq(prog,Deop+Dop); %Dop=-Deop
+        prog = lpi_eq(prog,Deop+Dop,'symmetric'); %Dop=-Deop
     end
     
     tempObj = B1op'*Wop*B1op;

--- a/PIETOOLS/executives/PIETOOLS_Hinf_control.m
+++ b/PIETOOLS/executives/PIETOOLS_Hinf_control.m
@@ -211,7 +211,7 @@ else
     end
     % derivative negativity
     % constraints
-    prog = lpi_eq(prog,Deop+Dop); %Dop=-Deop
+    prog = lpi_eq(prog,Deop+Dop,'symmetric'); %Dop=-Deop
 end
 
 %solving the sos program

--- a/PIETOOLS/executives/PIETOOLS_Hinf_estimator.m
+++ b/PIETOOLS/executives/PIETOOLS_Hinf_estimator.m
@@ -188,7 +188,7 @@ else
     else
         Deop=De1op;
     end
-    prog = lpi_eq(prog,Deop+Dop); %Dop=-Deop
+    prog = lpi_eq(prog,Deop+Dop,'symmetric'); %Dop=-Deop
 end
 
 

--- a/PIETOOLS/executives/PIETOOLS_Hinf_gain.m
+++ b/PIETOOLS/executives/PIETOOLS_Hinf_gain.m
@@ -180,7 +180,7 @@ else
     else
         Deop=De1op;
     end
-    prog = lpi_eq(prog,Deop+Dop); %Dop=-Deop
+    prog = lpi_eq(prog,Deop+Dop,'symmetric'); %Dop=-Deop
 end
 
 

--- a/PIETOOLS/executives/PIETOOLS_Hinf_gain_dual.m
+++ b/PIETOOLS/executives/PIETOOLS_Hinf_gain_dual.m
@@ -196,7 +196,7 @@ else
     else
         Deop=De1op;
     end
-    prog = lpi_eq(prog,Deop+Dop); %Dop=-Deop
+    prog = lpi_eq(prog,Deop+Dop,'symmetric'); %Dop=-Deop
 end
 
 

--- a/PIETOOLS/executives/PIETOOLS_stability.m
+++ b/PIETOOLS/executives/PIETOOLS_stability.m
@@ -148,7 +148,7 @@ else
     else
         Deop=De1op;
     end
-    prog = lpi_eq(prog,Dop+Deop); %Dop=-Deop
+    prog = lpi_eq(prog,Dop+Deop,'symmetric'); %Dop=-Deop
 end
 
 disp('- Solving the LPI using the specified SDP solver...');

--- a/PIETOOLS/executives/PIETOOLS_stability_dual.m
+++ b/PIETOOLS/executives/PIETOOLS_stability_dual.m
@@ -156,7 +156,7 @@ else
     else
         Deop=De1op;
     end
-    prog = lpi_eq(prog,Deop+Dop); %Dop=-Deop
+    prog = lpi_eq(prog,Deop+Dop,'symmetric'); %Dop=-Deop
 end
 
 disp('- Solving the LPI using the specified SDP solver...');

--- a/PIETOOLS/opvar/2D/LPI_programming/lpi_ineq_2d.m
+++ b/PIETOOLS/opvar/2D/LPI_programming/lpi_ineq_2d.m
@@ -47,8 +47,9 @@ function [sos,Deop] = lpi_ineq_2d(sos,Pop, options)
 % If you modify this code, document all changes carefully and include date
 % authorship, and a brief description of modifications
 %
-% Initial coding DJ - 07_21_2021 
-% 02/21/2022 - DJ: Update to allow multiple psatz terms
+% Initial coding MMP, SS, DJ - 07_21_2021 
+% 02/21/2022 - DJ: Update to allow multiple psatz terms;
+% 07/24/2023 - DJ: Update to exploit symmetry in lpi_eq;
 
 % Extract the inputs
 switch nargin
@@ -74,7 +75,7 @@ end
 
 dim = Pop.dim;
 if dim(:,1)~=dim(:,2)
-    error('Non-symmetric Operators cannot be sign definite. Unable to set the inequality');
+    error('Non-symmetric operators cannot be sign definite. Unable to set the inequality');
 end
 
 % We're going to enforce inequality P>=0, by building an operator Deop>=0,
@@ -185,19 +186,19 @@ if toggle==1    % Using maximal degrees
     end
 elseif toggle==2    % Using predefined monomials
     % % Add addtional terms with separable kernels
-    if any(~options2.exclude([3,4,9,10,13,14,15,16]))
-        options2.sep = [1,0,1,0,1,0];
-        [sosD, Deop_x] = poslpivar_2d(sosD, [n0, nx, ny, n2],dom,degs_oy,options2);
-    end
-    if any(~options2.exclude([6,7,11,12,13,14,15,16]))
-        options2.sep = [0,1,0,1,0,1];
-        [sosD, Deop_y] = poslpivar_2d(sosD, [n0, nx, ny, n2],dom,degs_xo,options2);
-    end
-    if any(~options2.exclude([3,4,6,7,9,10,11,12,13,14,15,16]))
-        options2.sep = [1,1,1,1,1,1];
-        [sosD, Deop_xy] = poslpivar_2d(sosD, [n0, nx, ny, n2],dom,degs_oo,options2);
-    end
-    Deop = Deop + Deop_x + Deop_y + Deop_xy;
+%     if any(~options2.exclude([3,4,9,10,13,14,15,16]))
+%         options2.sep = [1,0,1,0,1,0];
+%         [sosD, Deop_x] = poslpivar_2d(sosD, [n0, nx, ny, n2],dom,degs_oy,options2);
+%     end
+%     if any(~options2.exclude([6,7,11,12,13,14,15,16]))
+%         options2.sep = [0,1,0,1,0,1];
+%         [sosD, Deop_y] = poslpivar_2d(sosD, [n0, nx, ny, n2],dom,degs_xo,options2);
+%     end
+%     if any(~options2.exclude([3,4,6,7,9,10,11,12,13,14,15,16]))
+%         options2.sep = [1,1,1,1,1,1];
+%         [sosD, Deop_xy] = poslpivar_2d(sosD, [n0, nx, ny, n2],dom,degs_oo,options2);
+%     end
+%     Deop = Deop + Deop_x + Deop_y + Deop_xy;
 end
 sos = sosD; % Make sure the SOS program contains the right operator Deop
     
@@ -209,8 +210,8 @@ for j=1:length(options.psatz)
         Deop = Deop+De2op; 
     end
 end
-% Enforce the constraint
-sos = lpi_eq_2d(sos,Deop-Pop);  %Pop==Deop
+% Enforce the constraint, exploiting symmetry
+sos = lpi_eq_2d(sos,Deop-Pop,'symmetric');  %Pop==Deop
 
 end
 

--- a/PIETOOLS/opvar/lpi_ineq.m
+++ b/PIETOOLS/opvar/lpi_ineq.m
@@ -94,9 +94,9 @@ if options.psatz == 1
     options3.psatz=1;
     [sos, Deop] = poslpivar(sos, [nx1 ,nx2],X,d2,options2);
     [sos, De2op] = poslpivar(sos, [nx1 ,nx2],X,d2,options3);
-    sos = lpi_eq(sos,Deop+De2op-P); %Dop=Deop+De2op
+    sos = lpi_eq(sos,Deop+De2op-P,'symmetric'); %Dop=Deop+De2op
 else
     [sos, Deop] = poslpivar(sos, [nx1 ,nx2],X,d2,options2);
-    sos = lpi_eq(sos,Deop-P); %Dop=Deop
+    sos = lpi_eq(sos,Deop-P,'symmetric'); %Dop=Deop
 end
 end


### PR DESCRIPTION
In most applications, and in particular any time we are using `lpi_ineq`, the operators which we set equal to zero using `lpi_eq `will be symmetric, so that e.g. Pop.Q1=Pop.Q2'. In this case, when requiring Pop=0, it suffices to enforce e.g. only Pop.Q1=0 to insure that also Pop.Q2=0, thus allowing the complexity of the SDP to be reduced slightly. The proposed update adds an optional argument to `lpi_eq`, so that when this argument is set to 'symmetric', the operator Pop is assumed to be symmetric, and only the "lower-triangular" parameters in this operator are set equal to zero.