### PR TITLE
Update opvar concatenations.

### DIFF
--- a/PIETOOLS/opvar/2D/@dopvar2d/horzcat.m
+++ b/PIETOOLS/opvar/2D/@dopvar2d/horzcat.m
@@ -1,12 +1,16 @@
 function [Pcat] = horzcat(varargin) 
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
-% [Pcat] = horzcat(varargin) takes n-inputs and concatentates them horizontally,
-% provided they satisfy the following criterias.
-% 1) Atleast one input is a dopvar2d variable.
-% 2) If all the inputs are not dopvar2d, then the operator maps from RxL2 to
-%    L2 or R to R. 
-% 3) Currently, it supports RxL2 to RxL2 concatenation only if ALL the inputs are
-%    dopvar2d.
+% [Pcat] = horzcat(varargin) takes n inputs and concatentates them horizontally,
+% provided they satisfy the following criteria:
+% 1) At least one input must be of type 'dopvar2d', and all other inputs 
+%       must be of type 'opvar2d' or 'dopvar2d';
+% 2) The output dimensions varargin{j}.dim(:,2) of all objects must match;
+% 3) The spatial variables varargin{j}.var1 and varargin{j}.var2, as well 
+%       as the domain varargin{j}.I of all objects must match;
+% 4) Concatenation should make sense within the context of the opvar2d class,
+%       that is, opvar2ds take inputs from RxL2[x]xL2[y]xL2[x,y], 
+%       so if the concatenated operator maps any other space, 
+%       e.g. L2[x]xRxL2[x,y]xL2[y], concatenation will be prohibited.
 % 
 % NOTES:
 % For support, contact M. Peet, Arizona State University at mpeet@asu.edu
@@ -37,160 +41,265 @@ function [Pcat] = horzcat(varargin)
 % authorship, and a brief description of modifications
 %
 % Initial coding DJ - 07_12_2021
+% DJ - 09/30/23: Prohibit "ambiguous" concatenations.
 
-
+% Deal with single input case
 if nargin==1
     Pcat = varargin{1};
-else
-    a = varargin{1};
-    b = varargin{2};
-    
-    if isa(a,'dopvar2d') || isa(a,'opvar2d')
-        a.dim = a.dim;
+    return
+end
+
+% Extract the operators
+a = varargin{1};    b = varargin{2};
+
+% Currently support only opvar-opvar concatenation
+if (~isa(a,'opvar2d') && ~isa(a,'dopvar2d')) || (~isa(b,'opvar2d') && ~isa(b,'dopvar2d'))
+    error('Only concatenation of dopvar2d objects with opvar2d and dopvar2d objects is currently supported')
+end
+% Check that domain and variables match
+if any(any(a.I~=b.I))|| ~all(strcmp(a.var1.varname,b.var1.varname)) || ~all(strcmp(a.var2.varname,b.var2.varname))
+    error('Operators being concatenated have different spatial domains or variables');
+end
+% Check that the output dimensions match
+a.dim = a.dim;  b.dim = b.dim;
+if any(a.dim(:,1)~=b.dim(:,1))
+    error('Cannot concatenate horizontally: Output dimensions of opvar2d objects do not match')
+end
+
+% Avoid "ambiguous" concatenations
+intype_a = find(a.dim(:,2),1,'last');   % What is the largest function space a maps?
+intype_b = find(b.dim(:,2),1,'first');  % What is the smallest function space b maps?
+if ~isempty(intype_a) && ~isempty(intype_b) && intype_b<intype_a
+    % a has columns mapping from L2, but b has columns mapping from R.
+    % Concatenation would place those columns of a to the right of
+    % those columns of b in the opvar, which we currently prohibit...
+    error('Proposed opvar2d concatenation is ambiguous, and currently prohibited')
+end
+
+% Finally, let's actually concatenate
+% Initialize the concatenated operator
+newdim = [a.dim(:,1),a.dim(:,2)+b.dim(:,2)];
+Pcat = dopvar2d([],newdim,a.I,a.var1,a.var2);
+
+% Only concatenate rows which are nonempty
+fset = {};
+perform_cat = zeros(4,1);
+if Pcat.dim(1,1)~=0
+    fset = [fset,'R00','R0x','R0y','R02'];
+    perform_cat(1) = 1;
+end
+if Pcat.dim(2,1)~=0
+    fset = [fset,'Rx0','Rxy'];
+    perform_cat(2) = 1;
+end
+if Pcat.dim(3,1)~=0
+    fset = [fset,'Ry0','Ryx'];
+    perform_cat(3) = 1;
+end
+if Pcat.dim(4,1)~=0
+    fset = [fset,'R20'];
+    perform_cat(4) = 1;
+end
+
+% Perform the concatenation
+for f=fset
+    Pcat.(f{:}) = [a.(f{:}) b.(f{:})];
+end
+for i=1:3
+    if perform_cat(2)
+        Pcat.Rxx{i,1} = [a.Rxx{i,1} b.Rxx{i,1}];
+        Pcat.Rx2{i,1} = [a.Rx2{i,1} b.Rx2{i,1}];
     end
-    if isa(b,'dopvar2d') || isa(b,'opvar2d')
-        b.dim = b.dim;
+    if perform_cat(3)
+        Pcat.Ryy{1,i} = [a.Ryy{1,i} b.Ryy{1,i}];
+        Pcat.Ry2{1,i} = [a.Ry2{1,i} b.Ry2{1,i}];
     end
-    
-    if ~isa(a,'dopvar2d') && ~isa(a,'opvar2d')
-        if ~isa(b,'dopvar2d') && ~isa(b,'opvar2d') % both are not dopvar2d variables
-            if size(a,1)~=size(b,1) 
-                error('Cannot concatentate horizontally. A and B have different output dimensions');
-            end
-            Pcat = [a b];
-        elseif all(b.dim(2:4,1)==0) % a() is from R to R, Note: For L2 to R, a needs to be an opvar2d
-            if size(a,1)~=b.dim(1,1) 
-                error('Cannot concatentate horizontally. A and B have different output dimensions');
-            end 
-            Pcat = b;
-            Pcat.R00 = [a b.R00];
-            Pcat.Rx0 = [zeros(b.dim(2,1),size(a,2)) b.Rx0];
-            Pcat.Ry0 = [zeros(b.dim(3,1),size(a,2)) b.Ry0];
-            Pcat.R20 = [zeros(b.dim(4,1),size(a,2)) b.R20];
-        elseif all(b.dim([1,3:4],1)==0) % a() is from R to L2[s1], Note: For L2 to L2, a needs to be an opvar2d
-            if size(a,1)~=b.dim(2,1) 
-                error('Cannot concatentate horizontally. A and B have different output dimensions');
-            end 
-            Pcat = b;
-            Pcat.R00 = [zeros(b.dim(1,1),size(a,2)) b.R00];
-            Pcat.Rx0 = [a b.Rx0];
-            Pcat.Ry0 = [zeros(b.dim(3,1),size(a,2)) b.Ry0];
-            Pcat.R20 = [zeros(b.dim(4,1),size(a,2)) b.R20];
-        elseif all(b.dim([1:2,4],1)==0) % a() is from R to L2[s2], Note: For L2 to L2, a needs to be an opvar2d
-            if size(a,1)~=b.dim(3,1) 
-                error('Cannot concatentate horizontally. A and B have different output dimensions');
-            end 
-            Pcat = b;
-            Pcat.R00 = [zeros(b.dim(1,1),size(a,2)) b.R00];
-            Pcat.Rx0 = [zeros(b.dim(2,1),size(a,2)) b.Ry0];
-            Pcat.Ry0 = [a b.Ry0];
-            Pcat.R20 = [zeros(b.dim(4,1),size(a,2)) b.R20];
-        elseif all(b.dim(1:3,1)==0) % a() is from R to L2[s1,s2], Note: For L2 to L2, a needs to be an opvar2d
-            if size(a,1)~=b.dim(4,1) 
-                error('Cannot concatentate horizontally. A and B have different output dimensions');
-            end 
-            Pcat = b;
-            Pcat.R00 = [zeros(b.dim(1,1),size(a,2)) b.R00];
-            Pcat.Rx0 = [zeros(b.dim(2,1),size(a,2)) b.Rx0];
-            Pcat.Ry0 = [zeros(b.dim(3,1),size(a,2)) b.Ry0];
-            Pcat.R20 = [a b.R20];
-        else %find if such an operation is valid in any useful scenario and implement it
-            error('Cannot concatenate horizontally. This feature is not yet supported.');
+    if perform_cat(4)
+        Pcat.R2x{i,1} = [a.R2x{i,1} b.R2x{i,1}];
+        Pcat.R2y{1,i} = [a.R2y{1,i} b.R2y{1,i}];
+        for j=1:3
+            Pcat.R22{i,j} = [a.R22{i,j} b.R22{i,j}];
         end
-    elseif ~isa(b,'dopvar2d') && ~isa(b,'opvar2d')
-        if all(a.dim(2:4,1)==0) % a() is from R to R, Note: L2 to L2 needs to be an opvar
-            if size(b,1)~=a.dim(1,1) 
-                error('Cannot concatentate horizontally. A and B have different output dimensions');
-            end
-            Pcat = a;
-            Pcat.R00 = [a.R00 b];
-            Pcat.Rx0 = [a.Rx0 zeros(a.dim(2,1),size(b,2))];
-            Pcat.Ry0 = [a.Ry0 zeros(a.dim(3,1),size(b,2))];
-            Pcat.R20 = [a.R20 zeros(a.dim(4,1),size(b,2))];
-        elseif all(a.dim([1,3:4],1)==0) % a() is from R to L2[s1], Note: L2 to L2 needs to be an opvar
-            if size(b,1)~=a.dim(2,1) 
-                error('Cannot concatentate horizontally. A and B have different output dimensions');
-            end
-            Pcat = a;
-            Pcat.R00 = [a.R00 zeros(a.dim(1,1),size(b,2))];
-            Pcat.Rx0 = [a.Rx0 b];
-            Pcat.Ry0 = [a.Ry0 zeros(a.dim(3,1),size(b,2))];
-            Pcat.R20 = [a.R20 zeros(a.dim(4,1),size(b,2))];
-        elseif all(a.dim([1:2,4],1)==0) % a() is from R to L2[s2], Note: L2 to L2 needs to be an opvar
-            if size(b,1)~=a.dim(3,1) 
-                error('Cannot concatentate horizontally. A and B have different output dimensions');
-            end
-            Pcat = a;
-            Pcat.R00 = [a.R00 zeros(a.dim(1,1),size(b,2))];
-            Pcat.Rx0 = [a.Rx0 zeros(a.dim(2,1),size(b,2))];
-            Pcat.Ry0 = [a.Ry0 b];
-            Pcat.R20 = [a.R20 zeros(a.dim(4,1),size(b,2))];
-        elseif all(a.dim(1:3,1)==0) % a() is from R to L2[s1,s2], Note: L2 to L2 needs to be an opvar
-            if size(b,1)~=a.dim(4,1) 
-                error('Cannot concatentate horizontally. A and B have different output dimensions');
-            end
-            Pcat = a;
-            Pcat.R00 = [a.R00 zeros(a.dim(1,1),size(b,2))];
-            Pcat.Rx0 = [a.Rx0 zeros(a.dim(2,1),size(b,2))];
-            Pcat.Ry0 = [a.Ry0 zeros(a.dim(3,1),size(b,2))];
-            Pcat.R20 = [a.R20 b];
-        else %find if such a operation is valid is any useful scenario and implement it
-            error('Cannot concatenate horizontally.This feature is not yet supported.');
-        end
-    else % Both arguments are opvar2d or dopvar2d
-        if any(b.dim(:,1)~=a.dim(:,1))
-            error('Cannot concatentate horizontally. A and B have different row dimensions');
-        elseif any(any(b.I~=a.I))
-            error('Cannot concatentate horizontally: A and B have different domains');
-        end
-        % Initialize the concatenated operator
-        newdim = [a.dim(:,1),a.dim(:,2)+b.dim(:,2)];
-        Pcat = dopvar2d([],newdim,a.I,a.var1,a.var2);
-        
-        % Only concatenate rows which are nonempty
-        fset = {};
-        r = zeros(4,1);
-        if Pcat.dim(1,1)~=0
-            fset = [fset,'R00','R0x','R0y','R02'];
-            r(1) = 1;
-        end
-        if Pcat.dim(2,1)~=0
-            fset = [fset,'Rx0','Rxy'];
-            r(2) = 1;
-        end
-        if Pcat.dim(3,1)~=0
-            fset = [fset,'Ry0','Ryx'];
-            r(3) = 1;
-        end
-        if Pcat.dim(4,1)~=0
-            fset = [fset,'R20'];
-            r(4) = 1;
-        end
-        
-        % Perform the concatenation
-        for f=fset
-            Pcat.(f{:}) = [a.(f{:}) b.(f{:})];
-        end
-        for i=1:3
-            if r(2)
-                Pcat.Rxx{i,1} = [a.Rxx{i,1} b.Rxx{i,1}];
-                Pcat.Rx2{i,1} = [a.Rx2{i,1} b.Rx2{i,1}];
-            end
-            if r(3)
-                Pcat.Ryy{1,i} = [a.Ryy{1,i} b.Ryy{1,i}];
-                Pcat.Ry2{1,i} = [a.Ry2{1,i} b.Ry2{1,i}];
-            end
-            if r(4)
-                Pcat.R2x{i,1} = [a.R2x{i,1} b.R2x{i,1}];
-                Pcat.R2y{1,i} = [a.R2y{1,i} b.R2y{1,i}];
-                for j=1:3
-                    Pcat.R22{i,j} = [a.R22{i,j} b.R22{i,j}];
-                end
-            end
-        end
-    end
-    if nargin>2 % check if there are more than 2 objects that need to stacked
-        Pcat = horzcat(Pcat, varargin{3:end});
     end
 end
+
+% For concatenation of more than two objects, just repeat
+if nargin>2 
+    Pcat = horzcat(Pcat, varargin{3:end});
 end
+
+end
+
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+%%%%%%%%%%  Old version, that allows "ambiguous" concatenation   %%%%%%%%%%
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+% [Pcat] = horzcat(varargin) takes n-inputs and concatentates them horizontally,
+% provided they satisfy the following criterias.
+% 1) Atleast one input is a dopvar2d variable.
+% 2) If all the inputs are not dopvar2d, then the operator maps from RxL2 to
+%    L2 or R to R. 
+% 3) Currently, it supports RxL2 to RxL2 concatenation only if ALL the inputs are
+%    dopvar2d.
+% 
+% NOTES:
+% For support, contact M. Peet, Arizona State University at mpeet@asu.edu
+% or D. Jagt at djagt@asu.edu
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+% 
+% if nargin==1
+%     Pcat = varargin{1};
+% else
+%     a = varargin{1};
+%     b = varargin{2};
+%     
+%     if isa(a,'dopvar2d') || isa(a,'opvar2d')
+%         a.dim = a.dim;
+%     end
+%     if isa(b,'dopvar2d') || isa(b,'opvar2d')
+%         b.dim = b.dim;
+%     end
+%     
+%     if ~isa(a,'dopvar2d') && ~isa(a,'opvar2d')
+%         if ~isa(b,'dopvar2d') && ~isa(b,'opvar2d') % both are not dopvar2d variables
+%             if size(a,1)~=size(b,1) 
+%                 error('Cannot concatentate horizontally. A and B have different output dimensions');
+%             end
+%             Pcat = [a b];
+%         elseif all(b.dim(2:4,1)==0) % a() is from R to R, Note: For L2 to R, a needs to be an opvar2d
+%             if size(a,1)~=b.dim(1,1) 
+%                 error('Cannot concatentate horizontally. A and B have different output dimensions');
+%             end 
+%             Pcat = b;
+%             Pcat.R00 = [a b.R00];
+%             Pcat.Rx0 = [zeros(b.dim(2,1),size(a,2)) b.Rx0];
+%             Pcat.Ry0 = [zeros(b.dim(3,1),size(a,2)) b.Ry0];
+%             Pcat.R20 = [zeros(b.dim(4,1),size(a,2)) b.R20];
+%         elseif all(b.dim([1,3:4],1)==0) % a() is from R to L2[s1], Note: For L2 to L2, a needs to be an opvar2d
+%             if size(a,1)~=b.dim(2,1) 
+%                 error('Cannot concatentate horizontally. A and B have different output dimensions');
+%             end 
+%             Pcat = b;
+%             Pcat.R00 = [zeros(b.dim(1,1),size(a,2)) b.R00];
+%             Pcat.Rx0 = [a b.Rx0];
+%             Pcat.Ry0 = [zeros(b.dim(3,1),size(a,2)) b.Ry0];
+%             Pcat.R20 = [zeros(b.dim(4,1),size(a,2)) b.R20];
+%         elseif all(b.dim([1:2,4],1)==0) % a() is from R to L2[s2], Note: For L2 to L2, a needs to be an opvar2d
+%             if size(a,1)~=b.dim(3,1) 
+%                 error('Cannot concatentate horizontally. A and B have different output dimensions');
+%             end 
+%             Pcat = b;
+%             Pcat.R00 = [zeros(b.dim(1,1),size(a,2)) b.R00];
+%             Pcat.Rx0 = [zeros(b.dim(2,1),size(a,2)) b.Ry0];
+%             Pcat.Ry0 = [a b.Ry0];
+%             Pcat.R20 = [zeros(b.dim(4,1),size(a,2)) b.R20];
+%         elseif all(b.dim(1:3,1)==0) % a() is from R to L2[s1,s2], Note: For L2 to L2, a needs to be an opvar2d
+%             if size(a,1)~=b.dim(4,1) 
+%                 error('Cannot concatentate horizontally. A and B have different output dimensions');
+%             end 
+%             Pcat = b;
+%             Pcat.R00 = [zeros(b.dim(1,1),size(a,2)) b.R00];
+%             Pcat.Rx0 = [zeros(b.dim(2,1),size(a,2)) b.Rx0];
+%             Pcat.Ry0 = [zeros(b.dim(3,1),size(a,2)) b.Ry0];
+%             Pcat.R20 = [a b.R20];
+%         else %find if such an operation is valid in any useful scenario and implement it
+%             error('Cannot concatenate horizontally. This feature is not yet supported.');
+%         end
+%     elseif ~isa(b,'dopvar2d') && ~isa(b,'opvar2d')
+%         if all(a.dim(2:4,1)==0) % a() is from R to R, Note: L2 to L2 needs to be an opvar
+%             if size(b,1)~=a.dim(1,1) 
+%                 error('Cannot concatentate horizontally. A and B have different output dimensions');
+%             end
+%             Pcat = a;
+%             Pcat.R00 = [a.R00 b];
+%             Pcat.Rx0 = [a.Rx0 zeros(a.dim(2,1),size(b,2))];
+%             Pcat.Ry0 = [a.Ry0 zeros(a.dim(3,1),size(b,2))];
+%             Pcat.R20 = [a.R20 zeros(a.dim(4,1),size(b,2))];
+%         elseif all(a.dim([1,3:4],1)==0) % a() is from R to L2[s1], Note: L2 to L2 needs to be an opvar
+%             if size(b,1)~=a.dim(2,1) 
+%                 error('Cannot concatentate horizontally. A and B have different output dimensions');
+%             end
+%             Pcat = a;
+%             Pcat.R00 = [a.R00 zeros(a.dim(1,1),size(b,2))];
+%             Pcat.Rx0 = [a.Rx0 b];
+%             Pcat.Ry0 = [a.Ry0 zeros(a.dim(3,1),size(b,2))];
+%             Pcat.R20 = [a.R20 zeros(a.dim(4,1),size(b,2))];
+%         elseif all(a.dim([1:2,4],1)==0) % a() is from R to L2[s2], Note: L2 to L2 needs to be an opvar
+%             if size(b,1)~=a.dim(3,1) 
+%                 error('Cannot concatentate horizontally. A and B have different output dimensions');
+%             end
+%             Pcat = a;
+%             Pcat.R00 = [a.R00 zeros(a.dim(1,1),size(b,2))];
+%             Pcat.Rx0 = [a.Rx0 zeros(a.dim(2,1),size(b,2))];
+%             Pcat.Ry0 = [a.Ry0 b];
+%             Pcat.R20 = [a.R20 zeros(a.dim(4,1),size(b,2))];
+%         elseif all(a.dim(1:3,1)==0) % a() is from R to L2[s1,s2], Note: L2 to L2 needs to be an opvar
+%             if size(b,1)~=a.dim(4,1) 
+%                 error('Cannot concatentate horizontally. A and B have different output dimensions');
+%             end
+%             Pcat = a;
+%             Pcat.R00 = [a.R00 zeros(a.dim(1,1),size(b,2))];
+%             Pcat.Rx0 = [a.Rx0 zeros(a.dim(2,1),size(b,2))];
+%             Pcat.Ry0 = [a.Ry0 zeros(a.dim(3,1),size(b,2))];
+%             Pcat.R20 = [a.R20 b];
+%         else %find if such a operation is valid is any useful scenario and implement it
+%             error('Cannot concatenate horizontally.This feature is not yet supported.');
+%         end
+%     else % Both arguments are opvar2d or dopvar2d
+%         if any(b.dim(:,1)~=a.dim(:,1))
+%             error('Cannot concatentate horizontally. A and B have different row dimensions');
+%         elseif any(any(b.I~=a.I))
+%             error('Cannot concatentate horizontally: A and B have different domains');
+%         end
+%         % Initialize the concatenated operator
+%         newdim = [a.dim(:,1),a.dim(:,2)+b.dim(:,2)];
+%         Pcat = dopvar2d([],newdim,a.I,a.var1,a.var2);
+%         
+%         % Only concatenate rows which are nonempty
+%         fset = {};
+%         r = zeros(4,1);
+%         if Pcat.dim(1,1)~=0
+%             fset = [fset,'R00','R0x','R0y','R02'];
+%             r(1) = 1;
+%         end
+%         if Pcat.dim(2,1)~=0
+%             fset = [fset,'Rx0','Rxy'];
+%             r(2) = 1;
+%         end
+%         if Pcat.dim(3,1)~=0
+%             fset = [fset,'Ry0','Ryx'];
+%             r(3) = 1;
+%         end
+%         if Pcat.dim(4,1)~=0
+%             fset = [fset,'R20'];
+%             r(4) = 1;
+%         end
+%         
+%         % Perform the concatenation
+%         for f=fset
+%             Pcat.(f{:}) = [a.(f{:}) b.(f{:})];
+%         end
+%         for i=1:3
+%             if r(2)
+%                 Pcat.Rxx{i,1} = [a.Rxx{i,1} b.Rxx{i,1}];
+%                 Pcat.Rx2{i,1} = [a.Rx2{i,1} b.Rx2{i,1}];
+%             end
+%             if r(3)
+%                 Pcat.Ryy{1,i} = [a.Ryy{1,i} b.Ryy{1,i}];
+%                 Pcat.Ry2{1,i} = [a.Ry2{1,i} b.Ry2{1,i}];
+%             end
+%             if r(4)
+%                 Pcat.R2x{i,1} = [a.R2x{i,1} b.R2x{i,1}];
+%                 Pcat.R2y{1,i} = [a.R2y{1,i} b.R2y{1,i}];
+%                 for j=1:3
+%                     Pcat.R22{i,j} = [a.R22{i,j} b.R22{i,j}];
+%                 end
+%             end
+%         end
+%     end
+%     if nargin>2 % check if there are more than 2 objects that need to stacked
+%         Pcat = horzcat(Pcat, varargin{3:end});
+%     end
+% end
+% end

--- a/PIETOOLS/opvar/2D/@dopvar2d/vertcat.m
+++ b/PIETOOLS/opvar/2D/@dopvar2d/vertcat.m
@@ -1,13 +1,17 @@
 function [Pcat] = vertcat(varargin)
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
-% [Pcat] = vertcat(varargin) takes n-inputs and concatentates them vertically,
-% provided they satisfy the following criterias.
-% 1) Atleast one input is an dopvar2d variable.
-% 2) If all the inputs are not dopvar2d, then the operator maps from R to
-% RxL2 or L2 to L2. 
-% 3) Currently, it supports RxL2 to RxL2 concatenation only if ALL the inputs are
-% dopvar2d.
-%
+% [Pcat] = vertcat(varargin) takes n inputs and concatentates them vertically,
+% provided they satisfy the following criteria:
+% 1) At least one input must be of type 'dopvar2d', and all other inputs 
+%       must be of type 'opvar2d' or 'dopvar2d';
+% 2) The input dimensions varargin{j}.dim(:,1) of all objects must match;
+% 3) The spatial variables varargin{j}.var1 and varargin{j}.var2, as well 
+%       as the domain varargin{j}.I of all objects must match;
+% 4) Concatenation should make sense within the context of the opvar2d class,
+%       that is, opvar2ds map to RxL2[x]xL2[y]xL2[x,y], 
+%       so if the concatenated operator maps to any other space, 
+%       e.g. L2[x]xRxL2[x,y]xL2[y], concatenation will be prohibited.
+% 
 % NOTES:
 % For support, contact M. Peet, Arizona State University at mpeet@asu.edu
 % or D. Jagt at djagt@asu.edu
@@ -37,181 +41,285 @@ function [Pcat] = vertcat(varargin)
 % authorship, and a brief description of modifications
 %
 % Initial coding DJ - 07_12_2021  
+% DJ - 09/30/23: Prohibit "ambiguous" concatenations.
 
-
-
+% Deal with single input case
 if nargin==1
     Pcat = varargin{1};
-else
-    a = varargin{1};
-    b = varargin{2};
-    
-    if isa(a,'dopvar2d') || isa(a,'opvar2d') % components must have consistent dimensions
-        a.dim = a.dim;
+    return
+end
+
+% Extract the operators
+a = varargin{1};    b = varargin{2};
+
+% Currently support only opvar-opvar concatenation
+if (~isa(a,'opvar2d') && ~isa(a,'dopvar2d')) || (~isa(b,'opvar2d') && ~isa(b,'dopvar2d'))
+    error('Only concatenation of dopvar2d objects with opvar2d and dopvar2d objects is currently supported')
+end
+% Check that domain and variables match
+if any(any(a.I~=b.I))|| ~all(strcmp(a.var1.varname,b.var1.varname)) || ~all(strcmp(a.var2.varname,b.var2.varname))
+    error('Operators being concatenated have different spatial domains or variables');
+end
+% Check that the input dimensions match
+a.dim = a.dim;  b.dim = b.dim;
+if any(a.dim(:,2)~=b.dim(:,2))
+    error('Cannot concatenate vertically: Input dimensions of opvar2d objects do not match')
+end
+
+% Avoid "ambiguous" concatenations
+intype_a = find(a.dim(:,1),1,'last');   % What is the largest function space a maps to?
+intype_b = find(b.dim(:,1),1,'first');  % What is the smallest function space b maps to?
+if ~isempty(intype_a) && ~isempty(intype_b) && intype_b<intype_a
+    % a has columns mapping from L2, but b has columns mapping from R.
+    % Concatenation would place those columns of a to the right of
+    % those columns of b in the opvar, which we currently prohibit...
+    error('Proposed opvar2d concatenation is ambiguous, and currently prohibited')
+end
+
+% Finally, let's actually concatenate
+% Initialize the concatenated operator
+newdim = [a.dim(:,1)+b.dim(:,1),a.dim(:,2)];
+Pcat = dopvar2d([],newdim,a.I,a.var1,a.var2);
+
+% Only concatenate columns which are nonempty
+fset = {};
+perform_cat = zeros(4,1);
+if Pcat.dim(1,2)~=0
+    fset = [fset,'R00','Rx0','Ry0','R20'];
+    perform_cat(1) = 1;
+end
+if Pcat.dim(2,2)~=0
+    fset = [fset,'R0x','Ryx'];
+    perform_cat(2) = 1;
+end
+if Pcat.dim(3,2)~=0
+    fset = [fset,'R0y','Rxy'];
+    perform_cat(3) = 1;
+end
+if Pcat.dim(4,2)~=0
+    fset = [fset,'R02'];
+    perform_cat(4) = 1;
+end
+
+% Perform the concatenation
+for f=fset
+    Pcat.(f{:}) = [a.(f{:}); b.(f{:})];
+end
+for i=1:3
+    if perform_cat(2)
+        Pcat.Rxx{i,1} = [a.Rxx{i,1}; b.Rxx{i,1}];
+        Pcat.Rx2{i,1} = [a.Rx2{i,1}; b.Rx2{i,1}];
     end
-    if isa(b,'dopvar2d') || isa(b,'opvar2d')
-        b.dim = b.dim;
+    if perform_cat(3)
+        Pcat.Ryy{1,i} = [a.Ryy{1,i}; b.Ryy{1,i}];
+        Pcat.Ry2{1,i} = [a.Ry2{1,i}; b.Ry2{1,i}];
     end
-    
-    if ~isa(a,'dopvar2d') && ~isa(a,'opvar2d')
-        if ~isa(b,'dopvar2d') && ~isa(b,'opvar2d')
-            if size(a,2)~=size(b,2)
-                error('Cannot concatentate vertically. A and B have different input dimensions');
-            end
-            Pcat = [a;b];
-        else
-            bdim = b.dim;                
-            if size(a,2)~=sum(bdim(:,2))
-                error("Cannot concatentate vertically. A and B have different input dimensions");
-            end
-            Pcat = b;
-            if all(bdim(2:4,2) == 0) % a() is from R to R
-                Pcat.R00 = [a; b.R00]; 
-                Pcat.R0x = [zeros(size(a,1),b.dim(2,2)); b.R0x];
-                Pcat.R0y = [zeros(size(a,1),b.dim(3,2)); b.R0y];
-                Pcat.R02 = [zeros(size(a,1),b.dim(4,2)); b.R02];
-            elseif all(bdim([1,3:4],2) == 0) % a() is from L2[s1] to L2[s1], Note: For L2 to R, a must be opvar2d 
-                Pcat.Rx0 = [zeros(size(a,1),b.dim(1,2)); b.Rx0];
-                Pcat.Rxx{1,1} = [a; b.Rxx{1,1}];
-                Pcat.Rxx{2,1} = [zeros(size(a,1),b.dim(2,2)); b.Rxx{2,1}];
-                Pcat.Rxx{3,1} = [zeros(size(a,1),b.dim(2,2)); b.Rxx{3,1}];
-                Pcat.Rxy = [zeros(size(a,1),b.dim(3,2)); b.Rxy];
-                Pcat.Rx2{1,1} = [zeros(size(a,1),b.dim(4,2)); b.Rx2{1,1}];
-                Pcat.Rx2{2,1} = [zeros(size(a,1),b.dim(4,2)); b.Rx2{2,1}];
-                Pcat.Rx2{3,1} = [zeros(size(a,1),b.dim(4,2)); b.Rx2{3,1}];
-            elseif all(bdim([1:2,4],2) == 0) % a() is from L2[s2] to L2[s2], Note: For L2 to R, a must be opvar2d 
-                Pcat.Ry0 = [zeros(size(a,1),b.dim(1,2)); b.Ry0];
-                Pcat.Ryx = [zeros(size(a,1),b.dim(2,2)); b.Ryx];
-                Pcat.Ryy{1,1} = [a; b.Ryy{1,1}];
-                Pcat.Ryy{1,2} = [zeros(size(a,1),b.dim(3,2)); b.Ryy{1,2}];
-                Pcat.Ryy{1,3} = [zeros(size(a,1),b.dim(3,2)); b.Ryy{1,3}];
-                Pcat.Ry2{1,1} = [zeros(size(a,1),b.dim(4,2)); b.Ry2{1,1}];
-                Pcat.Ry2{1,2} = [zeros(size(a,1),b.dim(4,2)); b.Ry2{1,2}];
-                Pcat.Ry2{1,3} = [zeros(size(a,1),b.dim(4,2)); b.Ry2{1,3}];
-            elseif all(bdim(1:3,2) == 0) % a() is from L2[s1,s2] to L2[s1,s2], Note: For L2 to R, a must be opvar2d 
-                Pcat.R20 = [zeros(size(a,1),b.dim(1,2)); b.R20];
-                Pcat.R2x{1,1} = [zeros(size(a,1),b.dim(2,2)); b.R2x{1,1}];
-                Pcat.R2x{2,1} = [zeros(size(a,1),b.dim(2,2)); b.R2x{2,1}];
-                Pcat.R2x{3,1} = [zeros(size(a,1),b.dim(2,2)); b.R2x{3,1}];
-                Pcat.R2y{1,1} = [zeros(size(a,1),b.dim(3,2)); b.R2y{1,1}];
-                Pcat.R2y{1,2} = [zeros(size(a,1),b.dim(3,2)); b.R2y{1,2}];
-                Pcat.R2y{1,3} = [zeros(size(a,1),b.dim(3,2)); b.R2y{1,3}];
-                Pcat.R22{1,1} = [a; b.R22{1,1}];
-                Pcat.R22{2,1} = [zeros(size(a,1),b.dim(4,2)); b.R22{2,1}];
-                Pcat.R22{3,1} = [zeros(size(a,1),b.dim(4,2)); b.R22{3,1}];
-                Pcat.R22{1,2} = [zeros(size(a,1),b.dim(4,2)); b.R22{1,2}];
-                Pcat.R22{2,2} = [zeros(size(a,1),b.dim(4,2)); b.R22{2,2}];
-                Pcat.R22{3,2} = [zeros(size(a,1),b.dim(4,2)); b.R22{3,2}];
-                Pcat.R22{1,3} = [zeros(size(a,1),b.dim(4,2)); b.R22{1,3}];
-                Pcat.R22{2,3} = [zeros(size(a,1),b.dim(4,2)); b.R22{2,3}];
-                Pcat.R22{3,3} = [zeros(size(a,1),b.dim(4,2)); b.R22{3,3}];
-            else %find if such an operation is valid in any useful scenario and implement it
-                error('Cannot concatenate vertically. This feature is not yet supported.');
-            end
+    if perform_cat(4)
+        Pcat.R2x{i,1} = [a.R2x{i,1}; b.R2x{i,1}];
+        Pcat.R2y{1,i} = [a.R2y{1,i}; b.R2y{1,i}];
+        for j=1:3
+            Pcat.R22{i,j} = [a.R22{i,j}; b.R22{i,j}];
         end
-    elseif ~isa(b,'dopvar2d') && ~isa(b,'opvar2d')
-        adim = a.dim;
-        if size(b,2)~=sum(adim(:,2))
-            error("Cannot concatentate vertically. A and B have different input dimensions");
-        end
-        Pcat = a;
-        if all(adim(2:4,2) == 0) % b() is from R to R
-            Pcat.R00 = [a.R00; b]; 
-            Pcat.R0x = [a.R0x; zeros(size(b,1),a.dim(2,2))];
-            Pcat.R0y = [a.R0y; zeros(size(b,1),a.dim(3,2))];
-            Pcat.R02 = [a.R02; zeros(size(b,1),a.dim(4,2))];
-        elseif all(adim([1,3:4],2) == 0) % b() is from L2[s1] to L2[s1]
-            Pcat.Rx0 = [a.Rx0; zeros(size(b,1),a.dim(1,2))];
-            Pcat.Rxx{1,1} = [a.Rxx{1,1}; b];
-            Pcat.Rxx{2,1} = [a.Rxx{2,1}; zeros(size(b,1),a.dim(2,2))];
-            Pcat.Rxx{3,1} = [a.Rxx{3,1}; zeros(size(b,1),a.dim(2,2))];
-            Pcat.Rxy = [a.Rxy; zeros(size(b,1),a.dim(3,2))];
-            Pcat.Rx2{1,1} = [a.Rx2{1,1}; zeros(size(b,1),a.dim(4,2))];
-            Pcat.Rx2{2,1} = [a.Rx2{2,1}; zeros(size(b,1),a.dim(4,2))];
-            Pcat.Rx2{3,1} = [a.Rx2{3,1}; zeros(size(b,1),a.dim(4,2))];
-        elseif all(adim([1:2,4],2) == 0) % b() is from L2[s2] to L2[s2]
-            Pcat.Ry0 = [a.Rx0; zeros(size(b,1),a.dim(1,2))];
-            Pcat.Ryx = [a.Ryx; zeros(size(b,1),a.dim(2,2))];
-            Pcat.Ryy{1,1} = [a.Ryy{1,1}; b];
-            Pcat.Ryy{1,2} = [a.Ryy{1,2}; zeros(size(b,1),a.dim(3,2))];
-            Pcat.Ryy{1,3} = [a.Ryy{1,3}; zeros(size(b,1),a.dim(3,2))];
-            Pcat.Ry2{1,1} = [a.Ry2{1,1}; zeros(size(b,1),a.dim(4,2))];
-            Pcat.Ry2{1,2} = [a.Ry2{1,2}; zeros(size(b,1),a.dim(4,2))];
-            Pcat.Ry2{1,3} = [a.Ry2{1,3}; zeros(size(b,1),a.dim(4,2))];
-        elseif all(adim(1:3,2) == 0) % b() is from L2[s1,s2] to L2[s1,s2]
-            Pcat.R20 = [a.Rx0; zeros(size(b,1),a.dim(1,2))];
-            Pcat.R2x{1,1} = [a.R2x{1,1}; zeros(size(b,1),a.dim(2,2))];
-            Pcat.R2x{2,1} = [a.R2x{2,1}; zeros(size(b,1),a.dim(2,2))];
-            Pcat.R2x{3,1} = [a.R2x{3,1}; zeros(size(b,1),a.dim(2,2))];
-            Pcat.R2y{1,1} = [a.R2y{1,1}; zeros(size(b,1),a.dim(3,2))];
-            Pcat.R2y{1,2} = [a.R2y{1,2}; zeros(size(b,1),a.dim(3,2))];
-            Pcat.R2y{1,3} = [a.R2y{1,3}; zeros(size(b,1),a.dim(3,2))];
-            Pcat.R22{1,1} = [a.R22{1,1}; b];
-            Pcat.R22{2,1} = [a.R22{2,1}; zeros(size(b,1),a.dim(4,2))];
-            Pcat.R22{3,1} = [a.R22{3,1}; zeros(size(b,1),a.dim(4,2))];
-            Pcat.R22{1,2} = [a.R22{1,2}; zeros(size(b,1),a.dim(4,2))];
-            Pcat.R22{2,2} = [a.R22{2,2}; zeros(size(b,1),a.dim(4,2))];
-            Pcat.R22{3,2} = [a.R22{3,2}; zeros(size(b,1),a.dim(4,2))];
-            Pcat.R22{1,3} = [a.R22{1,3}; zeros(size(b,1),a.dim(4,2))];
-            Pcat.R22{2,3} = [a.R22{2,3}; zeros(size(b,1),a.dim(4,2))];
-            Pcat.R22{3,3} = [a.R22{3,3}; zeros(size(b,1),a.dim(4,2))];
-        else %find if such an operation is valid in any useful scenario and implement it
-            error('Cannot concatenate vertically. This feature is not yet supported.');
-        end
-    else
-        if any(b.dim(:,2)~=a.dim(:,2))
-            error('Cannot concatentate horizontally. A and B have different column dimensions');
-        elseif any(any(b.I~=a.I))
-            error('Cannot concatentate horizontally: A and B have different domains');
-        end
-        % Initialize the concatenated operator
-        newdim = [a.dim(:,1)+b.dim(:,1),a.dim(:,2)];
-        Pcat = dopvar2d([],newdim,a.I,a.var1,a.var2);
-        
-        % Only concatenate columns which are nonempty
-        fset = {};
-        c = zeros(4,1);
-        if Pcat.dim(1,2)~=0
-            fset = [fset,'R00','Rx0','Ry0','R20'];
-            c(1) = 1;
-        end
-        if Pcat.dim(2,2)~=0
-            fset = [fset,'R0x','Ryx'];
-            c(2) = 1;
-        end
-        if Pcat.dim(3,2)~=0
-            fset = [fset,'R0y','Rxy'];
-            c(3) = 1;
-        end
-        if Pcat.dim(4,2)~=0
-            fset = [fset,'R02'];
-            c(4) = 1;
-        end
-        
-        % Perform the concatenation
-        for f=fset
-            Pcat.(f{:}) = [a.(f{:}); b.(f{:})];
-        end
-        for i=1:3
-            if c(2)
-                Pcat.Rxx{i,1} = [a.Rxx{i,1}; b.Rxx{i,1}];
-                Pcat.R2x{i,1} = [a.R2x{i,1}; b.R2x{i,1}];
-            end
-            if c(3)
-                Pcat.Ryy{1,i} = [a.Ryy{1,i}; b.Ryy{1,i}];
-                Pcat.R2y{1,i} = [a.R2y{1,i}; b.R2y{1,i}];
-            end
-            if c(4)
-                Pcat.Rx2{i,1} = [a.Rx2{i,1}; b.Rx2{i,1}];
-                Pcat.Ry2{1,i} = [a.Ry2{1,i}; b.Ry2{1,i}];
-                for j=1:3
-                    Pcat.R22{i,j} = [a.R22{i,j}; b.R22{i,j}];
-                end
-            end
-        end
-    end
-    if nargin>2 % Continue concatenation if inputs are more than 2
-        Pcat = vertcat(Pcat, varargin{3:end});
     end
 end
+
+% For concatenation of more than two objects, just repeat
+if nargin>2 
+    Pcat = vertcat(Pcat, varargin{3:end});
 end
+
+end
+
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+%%%%%%%%%%  Old version, that allows "ambiguous" concatenation   %%%%%%%%%%
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+% [Pcat] = vertcat(varargin) takes n-inputs and concatentates them vertically,
+% provided they satisfy the following criterias.
+% 1) Atleast one input is an dopvar2d variable.
+% 2) If all the inputs are not dopvar2d, then the operator maps from R to
+% RxL2 or L2 to L2. 
+% 3) Currently, it supports RxL2 to RxL2 concatenation only if ALL the inputs are
+% dopvar2d.
+%
+% NOTES:
+% For support, contact M. Peet, Arizona State University at mpeet@asu.edu
+% or D. Jagt at djagt@asu.edu
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+%
+% if nargin==1
+%     Pcat = varargin{1};
+% else
+%     a = varargin{1};
+%     b = varargin{2};
+%     
+%     if isa(a,'dopvar2d') || isa(a,'opvar2d') % components must have consistent dimensions
+%         a.dim = a.dim;
+%     end
+%     if isa(b,'dopvar2d') || isa(b,'opvar2d')
+%         b.dim = b.dim;
+%     end
+%     
+%     if ~isa(a,'dopvar2d') && ~isa(a,'opvar2d')
+%         if ~isa(b,'dopvar2d') && ~isa(b,'opvar2d')
+%             if size(a,2)~=size(b,2)
+%                 error('Cannot concatentate vertically. A and B have different input dimensions');
+%             end
+%             Pcat = [a;b];
+%         else
+%             bdim = b.dim;                
+%             if size(a,2)~=sum(bdim(:,2))
+%                 error("Cannot concatentate vertically. A and B have different input dimensions");
+%             end
+%             Pcat = b;
+%             if all(bdim(2:4,2) == 0) % a() is from R to R
+%                 Pcat.R00 = [a; b.R00]; 
+%                 Pcat.R0x = [zeros(size(a,1),b.dim(2,2)); b.R0x];
+%                 Pcat.R0y = [zeros(size(a,1),b.dim(3,2)); b.R0y];
+%                 Pcat.R02 = [zeros(size(a,1),b.dim(4,2)); b.R02];
+%             elseif all(bdim([1,3:4],2) == 0) % a() is from L2[s1] to L2[s1], Note: For L2 to R, a must be opvar2d 
+%                 Pcat.Rx0 = [zeros(size(a,1),b.dim(1,2)); b.Rx0];
+%                 Pcat.Rxx{1,1} = [a; b.Rxx{1,1}];
+%                 Pcat.Rxx{2,1} = [zeros(size(a,1),b.dim(2,2)); b.Rxx{2,1}];
+%                 Pcat.Rxx{3,1} = [zeros(size(a,1),b.dim(2,2)); b.Rxx{3,1}];
+%                 Pcat.Rxy = [zeros(size(a,1),b.dim(3,2)); b.Rxy];
+%                 Pcat.Rx2{1,1} = [zeros(size(a,1),b.dim(4,2)); b.Rx2{1,1}];
+%                 Pcat.Rx2{2,1} = [zeros(size(a,1),b.dim(4,2)); b.Rx2{2,1}];
+%                 Pcat.Rx2{3,1} = [zeros(size(a,1),b.dim(4,2)); b.Rx2{3,1}];
+%             elseif all(bdim([1:2,4],2) == 0) % a() is from L2[s2] to L2[s2], Note: For L2 to R, a must be opvar2d 
+%                 Pcat.Ry0 = [zeros(size(a,1),b.dim(1,2)); b.Ry0];
+%                 Pcat.Ryx = [zeros(size(a,1),b.dim(2,2)); b.Ryx];
+%                 Pcat.Ryy{1,1} = [a; b.Ryy{1,1}];
+%                 Pcat.Ryy{1,2} = [zeros(size(a,1),b.dim(3,2)); b.Ryy{1,2}];
+%                 Pcat.Ryy{1,3} = [zeros(size(a,1),b.dim(3,2)); b.Ryy{1,3}];
+%                 Pcat.Ry2{1,1} = [zeros(size(a,1),b.dim(4,2)); b.Ry2{1,1}];
+%                 Pcat.Ry2{1,2} = [zeros(size(a,1),b.dim(4,2)); b.Ry2{1,2}];
+%                 Pcat.Ry2{1,3} = [zeros(size(a,1),b.dim(4,2)); b.Ry2{1,3}];
+%             elseif all(bdim(1:3,2) == 0) % a() is from L2[s1,s2] to L2[s1,s2], Note: For L2 to R, a must be opvar2d 
+%                 Pcat.R20 = [zeros(size(a,1),b.dim(1,2)); b.R20];
+%                 Pcat.R2x{1,1} = [zeros(size(a,1),b.dim(2,2)); b.R2x{1,1}];
+%                 Pcat.R2x{2,1} = [zeros(size(a,1),b.dim(2,2)); b.R2x{2,1}];
+%                 Pcat.R2x{3,1} = [zeros(size(a,1),b.dim(2,2)); b.R2x{3,1}];
+%                 Pcat.R2y{1,1} = [zeros(size(a,1),b.dim(3,2)); b.R2y{1,1}];
+%                 Pcat.R2y{1,2} = [zeros(size(a,1),b.dim(3,2)); b.R2y{1,2}];
+%                 Pcat.R2y{1,3} = [zeros(size(a,1),b.dim(3,2)); b.R2y{1,3}];
+%                 Pcat.R22{1,1} = [a; b.R22{1,1}];
+%                 Pcat.R22{2,1} = [zeros(size(a,1),b.dim(4,2)); b.R22{2,1}];
+%                 Pcat.R22{3,1} = [zeros(size(a,1),b.dim(4,2)); b.R22{3,1}];
+%                 Pcat.R22{1,2} = [zeros(size(a,1),b.dim(4,2)); b.R22{1,2}];
+%                 Pcat.R22{2,2} = [zeros(size(a,1),b.dim(4,2)); b.R22{2,2}];
+%                 Pcat.R22{3,2} = [zeros(size(a,1),b.dim(4,2)); b.R22{3,2}];
+%                 Pcat.R22{1,3} = [zeros(size(a,1),b.dim(4,2)); b.R22{1,3}];
+%                 Pcat.R22{2,3} = [zeros(size(a,1),b.dim(4,2)); b.R22{2,3}];
+%                 Pcat.R22{3,3} = [zeros(size(a,1),b.dim(4,2)); b.R22{3,3}];
+%             else %find if such an operation is valid in any useful scenario and implement it
+%                 error('Cannot concatenate vertically. This feature is not yet supported.');
+%             end
+%         end
+%     elseif ~isa(b,'dopvar2d') && ~isa(b,'opvar2d')
+%         adim = a.dim;
+%         if size(b,2)~=sum(adim(:,2))
+%             error("Cannot concatentate vertically. A and B have different input dimensions");
+%         end
+%         Pcat = a;
+%         if all(adim(2:4,2) == 0) % b() is from R to R
+%             Pcat.R00 = [a.R00; b]; 
+%             Pcat.R0x = [a.R0x; zeros(size(b,1),a.dim(2,2))];
+%             Pcat.R0y = [a.R0y; zeros(size(b,1),a.dim(3,2))];
+%             Pcat.R02 = [a.R02; zeros(size(b,1),a.dim(4,2))];
+%         elseif all(adim([1,3:4],2) == 0) % b() is from L2[s1] to L2[s1]
+%             Pcat.Rx0 = [a.Rx0; zeros(size(b,1),a.dim(1,2))];
+%             Pcat.Rxx{1,1} = [a.Rxx{1,1}; b];
+%             Pcat.Rxx{2,1} = [a.Rxx{2,1}; zeros(size(b,1),a.dim(2,2))];
+%             Pcat.Rxx{3,1} = [a.Rxx{3,1}; zeros(size(b,1),a.dim(2,2))];
+%             Pcat.Rxy = [a.Rxy; zeros(size(b,1),a.dim(3,2))];
+%             Pcat.Rx2{1,1} = [a.Rx2{1,1}; zeros(size(b,1),a.dim(4,2))];
+%             Pcat.Rx2{2,1} = [a.Rx2{2,1}; zeros(size(b,1),a.dim(4,2))];
+%             Pcat.Rx2{3,1} = [a.Rx2{3,1}; zeros(size(b,1),a.dim(4,2))];
+%         elseif all(adim([1:2,4],2) == 0) % b() is from L2[s2] to L2[s2]
+%             Pcat.Ry0 = [a.Rx0; zeros(size(b,1),a.dim(1,2))];
+%             Pcat.Ryx = [a.Ryx; zeros(size(b,1),a.dim(2,2))];
+%             Pcat.Ryy{1,1} = [a.Ryy{1,1}; b];
+%             Pcat.Ryy{1,2} = [a.Ryy{1,2}; zeros(size(b,1),a.dim(3,2))];
+%             Pcat.Ryy{1,3} = [a.Ryy{1,3}; zeros(size(b,1),a.dim(3,2))];
+%             Pcat.Ry2{1,1} = [a.Ry2{1,1}; zeros(size(b,1),a.dim(4,2))];
+%             Pcat.Ry2{1,2} = [a.Ry2{1,2}; zeros(size(b,1),a.dim(4,2))];
+%             Pcat.Ry2{1,3} = [a.Ry2{1,3}; zeros(size(b,1),a.dim(4,2))];
+%         elseif all(adim(1:3,2) == 0) % b() is from L2[s1,s2] to L2[s1,s2]
+%             Pcat.R20 = [a.Rx0; zeros(size(b,1),a.dim(1,2))];
+%             Pcat.R2x{1,1} = [a.R2x{1,1}; zeros(size(b,1),a.dim(2,2))];
+%             Pcat.R2x{2,1} = [a.R2x{2,1}; zeros(size(b,1),a.dim(2,2))];
+%             Pcat.R2x{3,1} = [a.R2x{3,1}; zeros(size(b,1),a.dim(2,2))];
+%             Pcat.R2y{1,1} = [a.R2y{1,1}; zeros(size(b,1),a.dim(3,2))];
+%             Pcat.R2y{1,2} = [a.R2y{1,2}; zeros(size(b,1),a.dim(3,2))];
+%             Pcat.R2y{1,3} = [a.R2y{1,3}; zeros(size(b,1),a.dim(3,2))];
+%             Pcat.R22{1,1} = [a.R22{1,1}; b];
+%             Pcat.R22{2,1} = [a.R22{2,1}; zeros(size(b,1),a.dim(4,2))];
+%             Pcat.R22{3,1} = [a.R22{3,1}; zeros(size(b,1),a.dim(4,2))];
+%             Pcat.R22{1,2} = [a.R22{1,2}; zeros(size(b,1),a.dim(4,2))];
+%             Pcat.R22{2,2} = [a.R22{2,2}; zeros(size(b,1),a.dim(4,2))];
+%             Pcat.R22{3,2} = [a.R22{3,2}; zeros(size(b,1),a.dim(4,2))];
+%             Pcat.R22{1,3} = [a.R22{1,3}; zeros(size(b,1),a.dim(4,2))];
+%             Pcat.R22{2,3} = [a.R22{2,3}; zeros(size(b,1),a.dim(4,2))];
+%             Pcat.R22{3,3} = [a.R22{3,3}; zeros(size(b,1),a.dim(4,2))];
+%         else %find if such an operation is valid in any useful scenario and implement it
+%             error('Cannot concatenate vertically. This feature is not yet supported.');
+%         end
+%     else
+%         if any(b.dim(:,2)~=a.dim(:,2))
+%             error('Cannot concatentate horizontally. A and B have different column dimensions');
+%         elseif any(any(b.I~=a.I))
+%             error('Cannot concatentate horizontally: A and B have different domains');
+%         end
+%         % Initialize the concatenated operator
+%         newdim = [a.dim(:,1)+b.dim(:,1),a.dim(:,2)];
+%         Pcat = dopvar2d([],newdim,a.I,a.var1,a.var2);
+%         
+%         % Only concatenate columns which are nonempty
+%         fset = {};
+%         c = zeros(4,1);
+%         if Pcat.dim(1,2)~=0
+%             fset = [fset,'R00','Rx0','Ry0','R20'];
+%             c(1) = 1;
+%         end
+%         if Pcat.dim(2,2)~=0
+%             fset = [fset,'R0x','Ryx'];
+%             c(2) = 1;
+%         end
+%         if Pcat.dim(3,2)~=0
+%             fset = [fset,'R0y','Rxy'];
+%             c(3) = 1;
+%         end
+%         if Pcat.dim(4,2)~=0
+%             fset = [fset,'R02'];
+%             c(4) = 1;
+%         end
+%         
+%         % Perform the concatenation
+%         for f=fset
+%             Pcat.(f{:}) = [a.(f{:}); b.(f{:})];
+%         end
+%         for i=1:3
+%             if c(2)
+%                 Pcat.Rxx{i,1} = [a.Rxx{i,1}; b.Rxx{i,1}];
+%                 Pcat.R2x{i,1} = [a.R2x{i,1}; b.R2x{i,1}];
+%             end
+%             if c(3)
+%                 Pcat.Ryy{1,i} = [a.Ryy{1,i}; b.Ryy{1,i}];
+%                 Pcat.R2y{1,i} = [a.R2y{1,i}; b.R2y{1,i}];
+%             end
+%             if c(4)
+%                 Pcat.Rx2{i,1} = [a.Rx2{i,1}; b.Rx2{i,1}];
+%                 Pcat.Ry2{1,i} = [a.Ry2{1,i}; b.Ry2{1,i}];
+%                 for j=1:3
+%                     Pcat.R22{i,j} = [a.R22{i,j}; b.R22{i,j}];
+%                 end
+%             end
+%         end
+%     end
+%     if nargin>2 % Continue concatenation if inputs are more than 2
+%         Pcat = vertcat(Pcat, varargin{3:end});
+%     end
+% end
+% end

--- a/PIETOOLS/opvar/2D/@opvar2d/horzcat.m
+++ b/PIETOOLS/opvar/2D/@opvar2d/horzcat.m
@@ -1,12 +1,15 @@
 function [Pcat] = horzcat(varargin) 
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
-% [Pcat] = horzcat(varargin) takes n-inputs and concatentates them horizontally,
-% provided they satisfy the following criterias.
-% 1) Atleast one input is an opvar2d variable.
-% 2) If all the inputs are not opvar2d, then the operator maps from RxL2 to
-%    L2 or R to R. 
-% 3) Currently, it supports RxL2 to RxL2 concatenation only if ALL the inputs are
-%    opvar2d.
+% [Pcat] = horzcat(varargin) takes n inputs and concatentates them horizontally,
+% provided they satisfy the following criteria:
+% 1) All inputs must of type 'opvar2d';
+% 2) The output dimensions varargin{j}.dim(:,2) of all objects must match;
+% 3) The spatial variables varargin{j}.var1 and varargin{j}.var2, as well 
+%       as the domain varargin{j}.I of all objects must match;
+% 4) Concatenation should make sense within the context of the opvar2d class,
+%       that is, opvar2ds take inputs from RxL2[x]xL2[y]xL2[x,y], 
+%       so if the concatenated operator maps any other space, 
+%       e.g. L2[x]xRxL2[x,y]xL2[y], concatenation will be prohibited.
 % 
 % NOTES:
 % For support, contact M. Peet, Arizona State University at mpeet@asu.edu
@@ -38,184 +41,289 @@ function [Pcat] = horzcat(varargin)
 %
 % Initial coding DJ - 02_04_2021  
 %   ^ Based heavily on "@opvar"-horzcat code by SS ^
+% DJ - 09/30/23: Prohibit "ambiguous" concatenations.
 
-
+% Deal with single input case
 if nargin==1
     Pcat = varargin{1};
-else
-    a = varargin{1};
-    b = varargin{2};
-    
-    if isa(a,'opvar2d')
-        a.dim = a.dim;
+    return
+end
+
+% Extract the operators
+a = varargin{1};    b = varargin{2};
+
+% Currently support only opvar-opvar concatenation
+if ~isa(a,'opvar2d') || ~isa(b,'opvar2d')
+    error('Concatenation of opvar2d and non-opvar2d objects is ambiguous, and currently not supported')
+end
+% Check that domain and variables match
+if any(any(a.I~=b.I))|| ~all(strcmp(a.var1.varname,b.var1.varname)) || ~all(strcmp(a.var2.varname,b.var2.varname))
+    error('Operators being concatenated have different spatial domains or variables');
+end
+% Check that the output dimensions match
+a.dim = a.dim;  b.dim = b.dim;
+if any(a.dim(:,1)~=b.dim(:,1))
+    error('Cannot concatenate horizontally: Output dimensions of opvar2d objects do not match')
+end
+
+% Avoid "ambiguous" concatenations
+intype_a = find(a.dim(:,2),1,'last');   % What is the largest function space a maps?
+intype_b = find(b.dim(:,2),1,'first');  % What is the smallest function space b maps?
+if ~isempty(intype_a) && ~isempty(intype_b) && intype_b<intype_a
+    % a has columns mapping from L2, but b has columns mapping from R.
+    % Concatenation would place those columns of a to the right of
+    % those columns of b in the opvar, which we currently prohibit...
+    error('Proposed opvar2d concatenation is ambiguous, and currently prohibited')
+end
+
+% Finally, let's actually concatenate
+% Initialize the concatenated operator
+newdim = [a.dim(:,1),a.dim(:,2)+b.dim(:,2)];
+Pcat = opvar2d([],newdim,a.I,a.var1,a.var2);
+
+% Only concatenate rows which are nonempty
+fset = {};
+perform_cat = zeros(4,1);
+if Pcat.dim(1,1)~=0
+    fset = [fset,'R00','R0x','R0y','R02'];
+    perform_cat(1) = 1;
+end
+if Pcat.dim(2,1)~=0
+    fset = [fset,'Rx0','Rxy'];
+    perform_cat(2) = 1;
+end
+if Pcat.dim(3,1)~=0
+    fset = [fset,'Ry0','Ryx'];
+    perform_cat(3) = 1;
+end
+if Pcat.dim(4,1)~=0
+    fset = [fset,'R20'];
+    perform_cat(4) = 1;
+end
+
+% Perform the concatenation
+for f=fset
+    Pcat.(f{:}) = [a.(f{:}) b.(f{:})];
+end
+for i=1:3
+    if perform_cat(2)
+        Pcat.Rxx{i,1} = [a.Rxx{i,1} b.Rxx{i,1}];
+        Pcat.Rx2{i,1} = [a.Rx2{i,1} b.Rx2{i,1}];
     end
-    if isa(b,'opvar2d')
-        b.dim = b.dim;
+    if perform_cat(3)
+        Pcat.Ryy{1,i} = [a.Ryy{1,i} b.Ryy{1,i}];
+        Pcat.Ry2{1,i} = [a.Ry2{1,i} b.Ry2{1,i}];
     end
-    
-    if ~isa(a,'opvar2d')
-        if ~isa(b,'opvar2d') % both are not opvar2d variables
-            if size(a,1)~=size(b,1) 
-                error('Cannot concatentate horizontally. A and B have different output dimensions');
-            end
-            Pcat = [a b];
-        elseif all(b.dim(2:4,1)==0) % a() is from R to R, Note: For L2 to R, a needs to be an opvar2d
-            if size(a,1)~=b.dim(1,1) 
-                error('Cannot concatentate horizontally. A and B have different output dimensions');
-            end 
-            Pcat = b;
-            Pcat.dim(1,2) = Pcat.dim(1,2) + size(a,2);
-            if ~isempty(a)
-                Pcat.R00 = [a b.R00];
-                Pcat.Rx0 = [zeros(b.dim(2,1),size(a,2)) b.Rx0];
-                Pcat.Ry0 = [zeros(b.dim(3,1),size(a,2)) b.Ry0];
-                Pcat.R20 = [zeros(b.dim(4,1),size(a,2)) b.R20];
-            end
-        elseif all(b.dim([1,3:4],1)==0) % a() is from R to L2[s1], Note: For L2 to L2, a needs to be an opvar2d
-            if size(a,1)~=b.dim(2,1) 
-                error('Cannot concatentate horizontally. A and B have different output dimensions');
-            end 
-            Pcat = b;
-            Pcat.dim(2,2) = Pcat.dim(2,2) + size(a,2);
-            if ~isempty(a)
-                Pcat.R00 = [zeros(b.dim(1,1),size(a,2)) b.R00];
-                Pcat.Rx0 = [a b.Rx0];
-                Pcat.Ry0 = [zeros(b.dim(3,1),size(a,2)) b.Ry0];
-                Pcat.R20 = [zeros(b.dim(4,1),size(a,2)) b.R20];
-            end
-        elseif all(b.dim([1:2,4],1)==0) % a() is from R to L2[s2], Note: For L2 to L2, a needs to be an opvar2d
-            if size(a,1)~=b.dim(3,1) 
-                error('Cannot concatentate horizontally. A and B have different output dimensions');
-            end 
-            Pcat = b;
-            Pcat.dim(3,2) = Pcat.dim(3,2) + size(a,2);
-            if ~isempty(a)
-                Pcat.R00 = [zeros(b.dim(1,1),size(a,2)) b.R00];
-                Pcat.Rx0 = [zeros(b.dim(2,1),size(a,2)) b.Ry0];
-                Pcat.Ry0 = [a b.Ry0];
-                Pcat.R20 = [zeros(b.dim(4,1),size(a,2)) b.R20];
-            end
-        elseif all(b.dim(1:3,1)==0) % a() is from R to L2[s1,s2], Note: For L2 to L2, a needs to be an opvar2d
-            if size(a,1)~=b.dim(4,1) 
-                error('Cannot concatentate horizontally. A and B have different output dimensions');
-            end 
-            Pcat = b;
-            Pcat.dim(4,2) = Pcat.dim(4,2) + size(a,2);
-            if ~isempty(a)
-                Pcat.R00 = [zeros(b.dim(1,1),size(a,2)) b.R00];
-                Pcat.Rx0 = [zeros(b.dim(2,1),size(a,2)) b.Rx0];
-                Pcat.Ry0 = [zeros(b.dim(3,1),size(a,2)) b.Ry0];
-                Pcat.R20 = [a b.R20];
-            end
-        else %find if such an operation is valid in any useful scenario and implement it
-            error('Cannot concatenate horizontally. This feature is not yet supported.');
+    if perform_cat(4)
+        Pcat.R2x{i,1} = [a.R2x{i,1} b.R2x{i,1}];
+        Pcat.R2y{1,i} = [a.R2y{1,i} b.R2y{1,i}];
+        for j=1:3
+            Pcat.R22{i,j} = [a.R22{i,j} b.R22{i,j}];
         end
-    elseif ~isa(b,'opvar2d')
-        if all(a.dim(2:4,1)==0) % a() is from R to R, Note: L2 to L2 needs to be an opvar
-            if size(b,1)~=a.dim(1,1) 
-                error('Cannot concatentate horizontally. A and B have different output dimensions');
-            end
-            Pcat = a;
-            Pcat.dim(1,2) = Pcat.dim(1,2) + size(b,2);
-            if ~isempty(b)
-                Pcat.R00 = [a.R00 b];
-                Pcat.Rx0 = [a.Rx0 zeros(a.dim(2,1),size(b,2))];
-                Pcat.Ry0 = [a.Ry0 zeros(a.dim(3,1),size(b,2))];
-                Pcat.R20 = [a.R20 zeros(a.dim(4,1),size(b,2))];
-            end
-        elseif all(a.dim([1,3:4],1)==0) % a() is from R to L2[s1], Note: L2 to L2 needs to be an opvar
-            if size(b,1)~=a.dim(2,1) 
-                error('Cannot concatentate horizontally. A and B have different output dimensions');
-            end
-            Pcat = a;
-            Pcat.dim(2,2) = Pcat.dim(2,2) + size(b,2);
-            if ~isempty(b)
-                Pcat.R00 = [a.R00 zeros(a.dim(1,1),size(b,2))];
-                Pcat.Rx0 = [a.Rx0 b];
-                Pcat.Ry0 = [a.Ry0 zeros(a.dim(3,1),size(b,2))];
-                Pcat.R20 = [a.R20 zeros(a.dim(4,1),size(b,2))];
-            end
-        elseif all(a.dim([1:2,4],1)==0) % a() is from R to L2[s2], Note: L2 to L2 needs to be an opvar
-            if size(b,1)~=a.dim(3,1) 
-                error('Cannot concatentate horizontally. A and B have different output dimensions');
-            end
-            Pcat = a;
-            Pcat.dim(3,2) = Pcat.dim(3,2) + size(b,2);
-            if ~isempty(b)
-                Pcat.R00 = [a.R00 zeros(a.dim(1,1),size(b,2))];
-                Pcat.Rx0 = [a.Rx0 zeros(a.dim(2,1),size(b,2))];
-                Pcat.Ry0 = [a.Ry0 b];
-                Pcat.R20 = [a.R20 zeros(a.dim(4,1),size(b,2))];
-            end
-        elseif all(a.dim(1:3,1)==0) % a() is from R to L2[s1,s2], Note: L2 to L2 needs to be an opvar
-            if size(b,1)~=a.dim(4,1) 
-                error('Cannot concatentate horizontally. A and B have different output dimensions');
-            end
-            Pcat = a;
-            Pcat.dim(4,2) = Pcat.dim(4,2) + size(b,2);
-            if ~isempty(b)
-                Pcat.R00 = [a.R00 zeros(a.dim(1,1),size(b,2))];
-                Pcat.Rx0 = [a.Rx0 zeros(a.dim(2,1),size(b,2))];
-                Pcat.Ry0 = [a.Ry0 zeros(a.dim(3,1),size(b,2))];
-                Pcat.R20 = [a.R20 b];
-            end
-        else %find if such a operation is valid in any useful scenario and implement it
-            error('Cannot concatenate horizontally. This feature is not yet supported.');
-        end
-    else % Both arguments are opvar2d
-        if any(b.dim(:,1)~=a.dim(:,1))
-            error('Cannot concatentate horizontally. A and B have different row dimensions');
-        elseif any(any(b.I~=a.I))
-            error('Cannot concatentate horizontally: A and B have different domains');
-        end
-        % Initialize the concatenated operator
-        newdim = [a.dim(:,1),a.dim(:,2)+b.dim(:,2)];
-        Pcat = opvar2d([],newdim,a.I,a.var1,a.var2);
-        
-        % Only concatenate rows which are nonempty
-        fset = {};
-        r = zeros(4,1);
-        if Pcat.dim(1,1)~=0
-            fset = [fset,'R00','R0x','R0y','R02'];
-            r(1) = 1;
-        end
-        if Pcat.dim(2,1)~=0
-            fset = [fset,'Rx0','Rxy'];
-            r(2) = 1;
-        end
-        if Pcat.dim(3,1)~=0
-            fset = [fset,'Ry0','Ryx'];
-            r(3) = 1;
-        end
-        if Pcat.dim(4,1)~=0
-            fset = [fset,'R20'];
-            r(4) = 1;
-        end
-        
-        % Perform the concatenation
-        for f=fset
-            Pcat.(f{:}) = [a.(f{:}) b.(f{:})];
-        end
-        for i=1:3
-            if r(2)
-                Pcat.Rxx{i,1} = [a.Rxx{i,1} b.Rxx{i,1}];
-                Pcat.Rx2{i,1} = [a.Rx2{i,1} b.Rx2{i,1}];
-            end
-            if r(3)
-                Pcat.Ryy{1,i} = [a.Ryy{1,i} b.Ryy{1,i}];
-                Pcat.Ry2{1,i} = [a.Ry2{1,i} b.Ry2{1,i}];
-            end
-            if r(4)
-                Pcat.R2x{i,1} = [a.R2x{i,1} b.R2x{i,1}];
-                Pcat.R2y{1,i} = [a.R2y{1,i} b.R2y{1,i}];
-                for j=1:3
-                    Pcat.R22{i,j} = [a.R22{i,j} b.R22{i,j}];
-                end
-            end
-        end
-    end
-    if nargin>2 % check if there are more than 2 objects that need to stacked
-        Pcat = horzcat(Pcat, varargin{3:end});
     end
 end
+
+% For concatenation of more than two objects, just repeat
+if nargin>2 
+    Pcat = horzcat(Pcat, varargin{3:end});
 end
+
+end
+
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+%%%%%%%%%%  Old version, that allows "ambiguous" concatenation   %%%%%%%%%%
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+% [Pcat] = horzcat(varargin) takes n-inputs and concatentates them horizontally,
+% provided they satisfy the following criterias.
+% 1) Atleast one input is an opvar2d variable.
+% 2) If all the inputs are not opvar2d, then the operator maps from RxL2 to
+%    L2 or R to R. 
+% 3) Currently, it supports RxL2 to RxL2 concatenation only if ALL the inputs are
+%    opvar2d.
+% 
+% NOTES:
+% For support, contact M. Peet, Arizona State University at mpeet@asu.edu
+% or D. Jagt at djagt@asu.edu
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+%
+% if nargin==1
+%     Pcat = varargin{1};
+% else
+%     a = varargin{1};
+%     b = varargin{2};
+%     
+%     if isa(a,'opvar2d')
+%         a.dim = a.dim;
+%     end
+%     if isa(b,'opvar2d')
+%         b.dim = b.dim;
+%     end
+%     
+%     if ~isa(a,'opvar2d')
+%         if ~isa(b,'opvar2d') % both are not opvar2d variables
+%             if size(a,1)~=size(b,1) 
+%                 error('Cannot concatentate horizontally. A and B have different output dimensions');
+%             end
+%             Pcat = [a b];
+%         elseif all(b.dim(2:4,1)==0) % a() is from R to R, Note: For L2 to R, a needs to be an opvar2d
+%             if size(a,1)~=b.dim(1,1) 
+%                 error('Cannot concatentate horizontally. A and B have different output dimensions');
+%             end 
+%             Pcat = b;
+%             Pcat.dim(1,2) = Pcat.dim(1,2) + size(a,2);
+%             if ~isempty(a)
+%                 Pcat.R00 = [a b.R00];
+%                 Pcat.Rx0 = [zeros(b.dim(2,1),size(a,2)) b.Rx0];
+%                 Pcat.Ry0 = [zeros(b.dim(3,1),size(a,2)) b.Ry0];
+%                 Pcat.R20 = [zeros(b.dim(4,1),size(a,2)) b.R20];
+%             end
+%         elseif all(b.dim([1,3:4],1)==0) % a() is from R to L2[s1], Note: For L2 to L2, a needs to be an opvar2d
+%             if size(a,1)~=b.dim(2,1) 
+%                 error('Cannot concatentate horizontally. A and B have different output dimensions');
+%             end 
+%             Pcat = b;
+%             Pcat.dim(2,2) = Pcat.dim(2,2) + size(a,2);
+%             if ~isempty(a)
+%                 Pcat.R00 = [zeros(b.dim(1,1),size(a,2)) b.R00];
+%                 Pcat.Rx0 = [a b.Rx0];
+%                 Pcat.Ry0 = [zeros(b.dim(3,1),size(a,2)) b.Ry0];
+%                 Pcat.R20 = [zeros(b.dim(4,1),size(a,2)) b.R20];
+%             end
+%         elseif all(b.dim([1:2,4],1)==0) % a() is from R to L2[s2], Note: For L2 to L2, a needs to be an opvar2d
+%             if size(a,1)~=b.dim(3,1) 
+%                 error('Cannot concatentate horizontally. A and B have different output dimensions');
+%             end 
+%             Pcat = b;
+%             Pcat.dim(3,2) = Pcat.dim(3,2) + size(a,2);
+%             if ~isempty(a)
+%                 Pcat.R00 = [zeros(b.dim(1,1),size(a,2)) b.R00];
+%                 Pcat.Rx0 = [zeros(b.dim(2,1),size(a,2)) b.Ry0];
+%                 Pcat.Ry0 = [a b.Ry0];
+%                 Pcat.R20 = [zeros(b.dim(4,1),size(a,2)) b.R20];
+%             end
+%         elseif all(b.dim(1:3,1)==0) % a() is from R to L2[s1,s2], Note: For L2 to L2, a needs to be an opvar2d
+%             if size(a,1)~=b.dim(4,1) 
+%                 error('Cannot concatentate horizontally. A and B have different output dimensions');
+%             end 
+%             Pcat = b;
+%             Pcat.dim(4,2) = Pcat.dim(4,2) + size(a,2);
+%             if ~isempty(a)
+%                 Pcat.R00 = [zeros(b.dim(1,1),size(a,2)) b.R00];
+%                 Pcat.Rx0 = [zeros(b.dim(2,1),size(a,2)) b.Rx0];
+%                 Pcat.Ry0 = [zeros(b.dim(3,1),size(a,2)) b.Ry0];
+%                 Pcat.R20 = [a b.R20];
+%             end
+%         else %find if such an operation is valid in any useful scenario and implement it
+%             error('Cannot concatenate horizontally. This feature is not yet supported.');
+%         end
+%     elseif ~isa(b,'opvar2d')
+%         if all(a.dim(2:4,1)==0) % a() is from R to R, Note: L2 to L2 needs to be an opvar
+%             if size(b,1)~=a.dim(1,1) 
+%                 error('Cannot concatentate horizontally. A and B have different output dimensions');
+%             end
+%             Pcat = a;
+%             Pcat.dim(1,2) = Pcat.dim(1,2) + size(b,2);
+%             if ~isempty(b)
+%                 Pcat.R00 = [a.R00 b];
+%                 Pcat.Rx0 = [a.Rx0 zeros(a.dim(2,1),size(b,2))];
+%                 Pcat.Ry0 = [a.Ry0 zeros(a.dim(3,1),size(b,2))];
+%                 Pcat.R20 = [a.R20 zeros(a.dim(4,1),size(b,2))];
+%             end
+%         elseif all(a.dim([1,3:4],1)==0) % a() is from R to L2[s1], Note: L2 to L2 needs to be an opvar
+%             if size(b,1)~=a.dim(2,1) 
+%                 error('Cannot concatentate horizontally. A and B have different output dimensions');
+%             end
+%             Pcat = a;
+%             Pcat.dim(2,2) = Pcat.dim(2,2) + size(b,2);
+%             if ~isempty(b)
+%                 Pcat.R00 = [a.R00 zeros(a.dim(1,1),size(b,2))];
+%                 Pcat.Rx0 = [a.Rx0 b];
+%                 Pcat.Ry0 = [a.Ry0 zeros(a.dim(3,1),size(b,2))];
+%                 Pcat.R20 = [a.R20 zeros(a.dim(4,1),size(b,2))];
+%             end
+%         elseif all(a.dim([1:2,4],1)==0) % a() is from R to L2[s2], Note: L2 to L2 needs to be an opvar
+%             if size(b,1)~=a.dim(3,1) 
+%                 error('Cannot concatentate horizontally. A and B have different output dimensions');
+%             end
+%             Pcat = a;
+%             Pcat.dim(3,2) = Pcat.dim(3,2) + size(b,2);
+%             if ~isempty(b)
+%                 Pcat.R00 = [a.R00 zeros(a.dim(1,1),size(b,2))];
+%                 Pcat.Rx0 = [a.Rx0 zeros(a.dim(2,1),size(b,2))];
+%                 Pcat.Ry0 = [a.Ry0 b];
+%                 Pcat.R20 = [a.R20 zeros(a.dim(4,1),size(b,2))];
+%             end
+%         elseif all(a.dim(1:3,1)==0) % a() is from R to L2[s1,s2], Note: L2 to L2 needs to be an opvar
+%             if size(b,1)~=a.dim(4,1) 
+%                 error('Cannot concatentate horizontally. A and B have different output dimensions');
+%             end
+%             Pcat = a;
+%             Pcat.dim(4,2) = Pcat.dim(4,2) + size(b,2);
+%             if ~isempty(b)
+%                 Pcat.R00 = [a.R00 zeros(a.dim(1,1),size(b,2))];
+%                 Pcat.Rx0 = [a.Rx0 zeros(a.dim(2,1),size(b,2))];
+%                 Pcat.Ry0 = [a.Ry0 zeros(a.dim(3,1),size(b,2))];
+%                 Pcat.R20 = [a.R20 b];
+%             end
+%         else %find if such a operation is valid in any useful scenario and implement it
+%             error('Cannot concatenate horizontally. This feature is not yet supported.');
+%         end
+%     else % Both arguments are opvar2d
+%         if any(b.dim(:,1)~=a.dim(:,1))
+%             error('Cannot concatentate horizontally. A and B have different row dimensions');
+%         elseif any(any(b.I~=a.I))
+%             error('Cannot concatentate horizontally: A and B have different domains');
+%         end
+%         % Initialize the concatenated operator
+%         newdim = [a.dim(:,1),a.dim(:,2)+b.dim(:,2)];
+%         Pcat = opvar2d([],newdim,a.I,a.var1,a.var2);
+%         
+%         % Only concatenate rows which are nonempty
+%         fset = {};
+%         r = zeros(4,1);
+%         if Pcat.dim(1,1)~=0
+%             fset = [fset,'R00','R0x','R0y','R02'];
+%             r(1) = 1;
+%         end
+%         if Pcat.dim(2,1)~=0
+%             fset = [fset,'Rx0','Rxy'];
+%             r(2) = 1;
+%         end
+%         if Pcat.dim(3,1)~=0
+%             fset = [fset,'Ry0','Ryx'];
+%             r(3) = 1;
+%         end
+%         if Pcat.dim(4,1)~=0
+%             fset = [fset,'R20'];
+%             r(4) = 1;
+%         end
+%         
+%         % Perform the concatenation
+%         for f=fset
+%             Pcat.(f{:}) = [a.(f{:}) b.(f{:})];
+%         end
+%         for i=1:3
+%             if r(2)
+%                 Pcat.Rxx{i,1} = [a.Rxx{i,1} b.Rxx{i,1}];
+%                 Pcat.Rx2{i,1} = [a.Rx2{i,1} b.Rx2{i,1}];
+%             end
+%             if r(3)
+%                 Pcat.Ryy{1,i} = [a.Ryy{1,i} b.Ryy{1,i}];
+%                 Pcat.Ry2{1,i} = [a.Ry2{1,i} b.Ry2{1,i}];
+%             end
+%             if r(4)
+%                 Pcat.R2x{i,1} = [a.R2x{i,1} b.R2x{i,1}];
+%                 Pcat.R2y{1,i} = [a.R2y{1,i} b.R2y{1,i}];
+%                 for j=1:3
+%                     Pcat.R22{i,j} = [a.R22{i,j} b.R22{i,j}];
+%                 end
+%             end
+%         end
+%     end
+%     if nargin>2 % check if there are more than 2 objects that need to stacked
+%         Pcat = horzcat(Pcat, varargin{3:end});
+%     end
+% end
+% end

--- a/PIETOOLS/opvar/2D/@opvar2d/vertcat.m
+++ b/PIETOOLS/opvar/2D/@opvar2d/vertcat.m
@@ -1,13 +1,16 @@
 function [Pcat] = vertcat(varargin)
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
-% [Pcat] = vertcat(varargin) takes n-inputs and concatentates them vertically,
-% provided they satisfy the following criterias.
-% 1) Atleast one input is an opvar2d variable.
-% 2) If all the inputs are not opvar2d, then the operator maps from R to
-% RxL2 or L2 to L2. 
-% 3) Currently, it supports RxL2 to RxL2 concatenation only if ALL the inputs are
-% opvar2d.
-%
+% [Pcat] = vertcat(varargin) takes n inputs and concatentates them vertically,
+% provided they satisfy the following criteria:
+% 1) All inputs must of type 'opvar2d';
+% 2) The input dimensions varargin{j}.dim(:,1) of all objects must match;
+% 3) The spatial variables varargin{j}.var1 and varargin{j}.var2, as well 
+%       as the domain varargin{j}.I of all objects must match;
+% 4) Concatenation should make sense within the context of the opvar2d class,
+%       that is, opvar2ds map to RxL2[x]xL2[y]xL2[x,y], 
+%       so if the concatenated operator maps to any other space, 
+%       e.g. L2[x]xRxL2[x,y]xL2[y], concatenation will be prohibited.
+% 
 % NOTES:
 % For support, contact M. Peet, Arizona State University at mpeet@asu.edu
 % or D. Jagt at djagt@asu.edu
@@ -38,187 +41,291 @@ function [Pcat] = vertcat(varargin)
 %
 % Initial coding DJ - 02_04_2021
 %   ^ Based heavily on "@opvar"-vertcat code by SS ^
+% DJ - 09/30/23: Prohibit "ambiguous" concatenations.
 
-
-
+% Deal with single input case
 if nargin==1
     Pcat = varargin{1};
-else
-    a = varargin{1};
-    b = varargin{2};
-    
-    if isa(a,'opvar2d') % components must have consistent dimensions
-        a.dim = a.dim;
+    return
+end
+
+% Extract the operators
+a = varargin{1};    b = varargin{2};
+
+% Currently support only opvar-opvar concatenation
+if ~isa(a,'opvar2d') || ~isa(b,'opvar2d')
+    error('Concatenation of opvar2d and non-opvar2d objects is ambiguous, and currently not supported')
+end
+% Check that domain and variables match
+if any(any(a.I~=b.I))|| ~all(strcmp(a.var1.varname,b.var1.varname)) || ~all(strcmp(a.var2.varname,b.var2.varname))
+    error('Operators being concatenated have different spatial domains or variables');
+end
+% Check that the input dimensions match
+a.dim = a.dim;  b.dim = b.dim;
+if any(a.dim(:,2)~=b.dim(:,2))
+    error('Cannot concatenate vertically: Input dimensions of opvar2d objects do not match')
+end
+
+% Avoid "ambiguous" concatenations
+intype_a = find(a.dim(:,1),1,'last');   % What is the largest function space a maps to?
+intype_b = find(b.dim(:,1),1,'first');  % What is the smallest function space b maps to?
+if ~isempty(intype_a) && ~isempty(intype_b) && intype_b<intype_a
+    % a has columns mapping from L2, but b has columns mapping from R.
+    % Concatenation would place those columns of a to the right of
+    % those columns of b in the opvar, which we currently prohibit...
+    error('Proposed opvar2d concatenation is ambiguous, and currently prohibited')
+end
+
+% Finally, let's actually concatenate
+% Initialize the concatenated operator
+newdim = [a.dim(:,1)+b.dim(:,1),a.dim(:,2)];
+Pcat = opvar2d([],newdim,a.I,a.var1,a.var2);
+
+% Only concatenate columns which are nonempty
+fset = {};
+perform_cat = zeros(4,1);
+if Pcat.dim(1,2)~=0
+    fset = [fset,'R00','Rx0','Ry0','R20'];
+    perform_cat(1) = 1;
+end
+if Pcat.dim(2,2)~=0
+    fset = [fset,'R0x','Ryx'];
+    perform_cat(2) = 1;
+end
+if Pcat.dim(3,2)~=0
+    fset = [fset,'R0y','Rxy'];
+    perform_cat(3) = 1;
+end
+if Pcat.dim(4,2)~=0
+    fset = [fset,'R02'];
+    perform_cat(4) = 1;
+end
+
+% Perform the concatenation
+for f=fset
+    Pcat.(f{:}) = [a.(f{:}); b.(f{:})];
+end
+for i=1:3
+    if perform_cat(2)
+        Pcat.Rxx{i,1} = [a.Rxx{i,1}; b.Rxx{i,1}];
+        Pcat.Rx2{i,1} = [a.Rx2{i,1}; b.Rx2{i,1}];
     end
-    if isa(b,'opvar2d')
-        b.dim = b.dim;
+    if perform_cat(3)
+        Pcat.Ryy{1,i} = [a.Ryy{1,i}; b.Ryy{1,i}];
+        Pcat.Ry2{1,i} = [a.Ry2{1,i}; b.Ry2{1,i}];
     end
-    
-    if ~isa(a,'opvar2d') 
-        if ~isa(b,'opvar2d')
-            if size(a,2)~=size(b,2)
-                error('Cannot concatentate vertically. A and B have different input dimensions');
-            end
-            Pcat = [a;b];
-        else
-            bdim = b.dim;                
-            if size(a,2)~=sum(bdim(:,2))
-                error("Cannot concatentate vertically. A and B have different input dimensions");
-            end
-            Pcat = b;
-            Pcat.dim = [b.dim(:,1)+(b.dim(:,1)~=0).*size(a,1),b.dim(:,2)];
-            if ~isempty(a)
-                if all(bdim(2:4,2) == 0) % a() is from R to R
-                    Pcat.R00 = [a; b.R00]; 
-                    Pcat.R0x = [zeros(size(a,1),b.dim(2,2)); b.R0x];
-                    Pcat.R0y = [zeros(size(a,1),b.dim(3,2)); b.R0y];
-                    Pcat.R02 = [zeros(size(a,1),b.dim(4,2)); b.R02];
-                elseif all(bdim([1,3:4],2) == 0) % a() is from L2[s1] to L2[s1], Note: For L2 to R, a must be opvar2d 
-                    Pcat.Rx0 = [zeros(size(a,1),b.dim(1,2)); b.Rx0];
-                    Pcat.Rxx{1,1} = [a; b.Rxx{1,1}];
-                    Pcat.Rxx{2,1} = [zeros(size(a,1),b.dim(2,2)); b.Rxx{2,1}];
-                    Pcat.Rxx{3,1} = [zeros(size(a,1),b.dim(2,2)); b.Rxx{3,1}];
-                    Pcat.Rxy = [zeros(size(a,1),b.dim(3,2)); b.Rxy];
-                    Pcat.Rx2{1,1} = [zeros(size(a,1),b.dim(4,2)); b.Rx2{1,1}];
-                    Pcat.Rx2{2,1} = [zeros(size(a,1),b.dim(4,2)); b.Rx2{2,1}];
-                    Pcat.Rx2{3,1} = [zeros(size(a,1),b.dim(4,2)); b.Rx2{3,1}];
-                elseif all(bdim([1:2,4],2) == 0) % a() is from L2[s2] to L2[s2], Note: For L2 to R, a must be opvar2d 
-                    Pcat.Ry0 = [zeros(size(a,1),b.dim(1,2)); b.Ry0];
-                    Pcat.Ryx = [zeros(size(a,1),b.dim(2,2)); b.Ryx];
-                    Pcat.Ryy{1,1} = [a; b.Ryy{1,1}];
-                    Pcat.Ryy{1,2} = [zeros(size(a,1),b.dim(3,2)); b.Ryy{1,2}];
-                    Pcat.Ryy{1,3} = [zeros(size(a,1),b.dim(3,2)); b.Ryy{1,3}];
-                    Pcat.Ry2{1,1} = [zeros(size(a,1),b.dim(4,2)); b.Ry2{1,1}];
-                    Pcat.Ry2{1,2} = [zeros(size(a,1),b.dim(4,2)); b.Ry2{1,2}];
-                    Pcat.Ry2{1,3} = [zeros(size(a,1),b.dim(4,2)); b.Ry2{1,3}];
-                elseif all(bdim(1:3,2) == 0) % a() is from L2[s1,s2] to L2[s1,s2], Note: For L2 to R, a must be opvar2d 
-                    Pcat.R20 = [zeros(size(a,1),b.dim(1,2)); b.R20];
-                    Pcat.R2x{1,1} = [zeros(size(a,1),b.dim(2,2)); b.R2x{1,1}];
-                    Pcat.R2x{2,1} = [zeros(size(a,1),b.dim(2,2)); b.R2x{2,1}];
-                    Pcat.R2x{3,1} = [zeros(size(a,1),b.dim(2,2)); b.R2x{3,1}];
-                    Pcat.R2y{1,1} = [zeros(size(a,1),b.dim(3,2)); b.R2y{1,1}];
-                    Pcat.R2y{1,2} = [zeros(size(a,1),b.dim(3,2)); b.R2y{1,2}];
-                    Pcat.R2y{1,3} = [zeros(size(a,1),b.dim(3,2)); b.R2y{1,3}];
-                    Pcat.R22{1,1} = [a; b.R22{1,1}];
-                    Pcat.R22{2,1} = [zeros(size(a,1),b.dim(4,2)); b.R22{2,1}];
-                    Pcat.R22{3,1} = [zeros(size(a,1),b.dim(4,2)); b.R22{3,1}];
-                    Pcat.R22{1,2} = [zeros(size(a,1),b.dim(4,2)); b.R22{1,2}];
-                    Pcat.R22{2,2} = [zeros(size(a,1),b.dim(4,2)); b.R22{2,2}];
-                    Pcat.R22{3,2} = [zeros(size(a,1),b.dim(4,2)); b.R22{3,2}];
-                    Pcat.R22{1,3} = [zeros(size(a,1),b.dim(4,2)); b.R22{1,3}];
-                    Pcat.R22{2,3} = [zeros(size(a,1),b.dim(4,2)); b.R22{2,3}];
-                    Pcat.R22{3,3} = [zeros(size(a,1),b.dim(4,2)); b.R22{3,3}];
-                else %find if such an operation is valid in any useful scenario and implement it
-                    error('Cannot concatenate vertically. This feature is not yet supported.');
-                end
-            end
+    if perform_cat(4)
+        Pcat.R2x{i,1} = [a.R2x{i,1}; b.R2x{i,1}];
+        Pcat.R2y{1,i} = [a.R2y{1,i}; b.R2y{1,i}];
+        for j=1:3
+            Pcat.R22{i,j} = [a.R22{i,j}; b.R22{i,j}];
         end
-    elseif ~isa(b,'opvar2d') 
-        adim = a.dim;
-        if size(b,2)~=sum(adim(:,2))
-            error("Cannot concatentate vertically. A and B have different input dimensions");
-        end
-        Pcat = a;
-        Pcat.dim = [a.dim(:,1)+(a.dim(:,1)~=0).*size(b,1),a.dim(:,2)];
-        if ~isempty(b)
-            if all(adim(2:4,2) == 0) % b() is from R to R
-                Pcat.R00 = [a.R00; b]; 
-                Pcat.R0x = [a.R0x; zeros(size(b,1),a.dim(2,2))];
-                Pcat.R0y = [a.R0y; zeros(size(b,1),a.dim(3,2))];
-                Pcat.R02 = [a.R02; zeros(size(b,1),a.dim(4,2))];
-            elseif all(adim([1,3:4],2) == 0) % b() is from L2[s1] to L2[s1]
-                Pcat.Rx0 = [a.Rx0; zeros(size(b,1),a.dim(1,2))];
-                Pcat.Rxx{1,1} = [a.Rxx{1,1}; b];
-                Pcat.Rxx{2,1} = [a.Rxx{2,1}; zeros(size(b,1),a.dim(2,2))];
-                Pcat.Rxx{3,1} = [a.Rxx{3,1}; zeros(size(b,1),a.dim(2,2))];
-                Pcat.Rxy = [a.Rxy; zeros(size(b,1),a.dim(3,2))];
-                Pcat.Rx2{1,1} = [a.Rx2{1,1}; zeros(size(b,1),a.dim(4,2))];
-                Pcat.Rx2{2,1} = [a.Rx2{2,1}; zeros(size(b,1),a.dim(4,2))];
-                Pcat.Rx2{3,1} = [a.Rx2{3,1}; zeros(size(b,1),a.dim(4,2))];
-            elseif all(adim([1:2,4],2) == 0) % b() is from L2[s2] to L2[s2]
-                Pcat.Ry0 = [a.Ry0; zeros(size(b,1),a.dim(1,2))];
-                Pcat.Ryx = [a.Ryx; zeros(size(b,1),a.dim(2,2))];
-                Pcat.Ryy{1,1} = [a.Ryy{1,1}; b];
-                Pcat.Ryy{1,2} = [a.Ryy{1,2}; zeros(size(b,1),a.dim(3,2))];
-                Pcat.Ryy{1,3} = [a.Ryy{1,3}; zeros(size(b,1),a.dim(3,2))];
-                Pcat.Ry2{1,1} = [a.Ry2{1,1}; zeros(size(b,1),a.dim(4,2))];
-                Pcat.Ry2{1,2} = [a.Ry2{1,2}; zeros(size(b,1),a.dim(4,2))];
-                Pcat.Ry2{1,3} = [a.Ry2{1,3}; zeros(size(b,1),a.dim(4,2))];
-            elseif all(adim(1:3,2) == 0) % b() is from L2[s1,s2] to L2[s1,s2]
-                Pcat.R20 = [a.R20; zeros(size(b,1),a.dim(1,2))];
-                Pcat.R2x{1,1} = [a.R2x{1,1}; zeros(size(b,1),a.dim(2,2))];
-                Pcat.R2x{2,1} = [a.R2x{2,1}; zeros(size(b,1),a.dim(2,2))];
-                Pcat.R2x{3,1} = [a.R2x{3,1}; zeros(size(b,1),a.dim(2,2))];
-                Pcat.R2y{1,1} = [a.R2y{1,1}; zeros(size(b,1),a.dim(3,2))];
-                Pcat.R2y{1,2} = [a.R2y{1,2}; zeros(size(b,1),a.dim(3,2))];
-                Pcat.R2y{1,3} = [a.R2y{1,3}; zeros(size(b,1),a.dim(3,2))];
-                Pcat.R22{1,1} = [a.R22{1,1}; b];
-                Pcat.R22{2,1} = [a.R22{2,1}; zeros(size(b,1),a.dim(4,2))];
-                Pcat.R22{3,1} = [a.R22{3,1}; zeros(size(b,1),a.dim(4,2))];
-                Pcat.R22{1,2} = [a.R22{1,2}; zeros(size(b,1),a.dim(4,2))];
-                Pcat.R22{2,2} = [a.R22{2,2}; zeros(size(b,1),a.dim(4,2))];
-                Pcat.R22{3,2} = [a.R22{3,2}; zeros(size(b,1),a.dim(4,2))];
-                Pcat.R22{1,3} = [a.R22{1,3}; zeros(size(b,1),a.dim(4,2))];
-                Pcat.R22{2,3} = [a.R22{2,3}; zeros(size(b,1),a.dim(4,2))];
-                Pcat.R22{3,3} = [a.R22{3,3}; zeros(size(b,1),a.dim(4,2))];
-            else %find if such an operation is valid in any useful scenario and implement it
-                error('Cannot concatenate vertically. This feature is not yet supported.');
-            end
-        end
-    else
-        if any(b.dim(:,2)~=a.dim(:,2))
-            error('Cannot concatentate horizontally. A and B have different column dimensions');
-        elseif any(any(b.I~=a.I))
-            error('Cannot concatentate horizontally: A and B have different domains');
-        end
-        % Initialize the concatenated operator
-        newdim = [a.dim(:,1)+b.dim(:,1),a.dim(:,2)];
-        Pcat = opvar2d([],newdim,a.I,a.var1,a.var2);
-        
-        % Only concatenate columns which are nonempty
-        fset = {};
-        c = zeros(4,1);
-        if Pcat.dim(1,2)~=0
-            fset = [fset,'R00','Rx0','Ry0','R20'];
-            c(1) = 1;
-        end
-        if Pcat.dim(2,2)~=0
-            fset = [fset,'R0x','Ryx'];
-            c(2) = 1;
-        end
-        if Pcat.dim(3,2)~=0
-            fset = [fset,'R0y','Rxy'];
-            c(3) = 1;
-        end
-        if Pcat.dim(4,2)~=0
-            fset = [fset,'R02'];
-            c(4) = 1;
-        end
-        
-        % Perform the concatenation
-        for f=fset
-            Pcat.(f{:}) = [a.(f{:}); b.(f{:})];
-        end
-        for i=1:3
-            if c(2)
-                Pcat.Rxx{i,1} = [a.Rxx{i,1}; b.Rxx{i,1}];
-                Pcat.R2x{i,1} = [a.R2x{i,1}; b.R2x{i,1}];
-            end
-            if c(3)
-                Pcat.Ryy{1,i} = [a.Ryy{1,i}; b.Ryy{1,i}];
-                Pcat.R2y{1,i} = [a.R2y{1,i}; b.R2y{1,i}];
-            end
-            if c(4)
-                Pcat.Rx2{i,1} = [a.Rx2{i,1}; b.Rx2{i,1}];
-                Pcat.Ry2{1,i} = [a.Ry2{1,i}; b.Ry2{1,i}];
-                for j=1:3
-                    Pcat.R22{i,j} = [a.R22{i,j}; b.R22{i,j}];
-                end
-            end
-        end
-    end
-    if nargin>2 % Continue concatenation if inputs are more than 2
-        Pcat = vertcat(Pcat, varargin{3:end});
     end
 end
+
+% For concatenation of more than two objects, just repeat
+if nargin>2 
+    Pcat = vertcat(Pcat, varargin{3:end});
 end
+
+end
+
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+%%%%%%%%%%  Old version, that allows "ambiguous" concatenation   %%%%%%%%%%
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+% [Pcat] = vertcat(varargin) takes n-inputs and concatentates them vertically,
+% provided they satisfy the following criterias.
+% 1) Atleast one input is an opvar2d variable.
+% 2) If all the inputs are not opvar2d, then the operator maps from R to
+% RxL2 or L2 to L2. 
+% 3) Currently, it supports RxL2 to RxL2 concatenation only if ALL the inputs are
+% opvar2d.
+%
+% NOTES:
+% For support, contact M. Peet, Arizona State University at mpeet@asu.edu
+% or D. Jagt at djagt@asu.edu
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+%
+% if nargin==1
+%     Pcat = varargin{1};
+% else
+%     a = varargin{1};
+%     b = varargin{2};
+%     
+%     if isa(a,'opvar2d') % components must have consistent dimensions
+%         a.dim = a.dim;
+%     end
+%     if isa(b,'opvar2d')
+%         b.dim = b.dim;
+%     end
+%     
+%     if ~isa(a,'opvar2d') 
+%         if ~isa(b,'opvar2d')
+%             if size(a,2)~=size(b,2)
+%                 error('Cannot concatentate vertically. A and B have different input dimensions');
+%             end
+%             Pcat = [a;b];
+%         else
+%             bdim = b.dim;                
+%             if size(a,2)~=sum(bdim(:,2))
+%                 error("Cannot concatentate vertically. A and B have different input dimensions");
+%             end
+%             Pcat = b;
+%             Pcat.dim = [b.dim(:,1)+(b.dim(:,1)~=0).*size(a,1),b.dim(:,2)];
+%             if ~isempty(a)
+%                 if all(bdim(2:4,2) == 0) % a() is from R to R
+%                     Pcat.R00 = [a; b.R00]; 
+%                     Pcat.R0x = [zeros(size(a,1),b.dim(2,2)); b.R0x];
+%                     Pcat.R0y = [zeros(size(a,1),b.dim(3,2)); b.R0y];
+%                     Pcat.R02 = [zeros(size(a,1),b.dim(4,2)); b.R02];
+%                 elseif all(bdim([1,3:4],2) == 0) % a() is from L2[s1] to L2[s1], Note: For L2 to R, a must be opvar2d 
+%                     Pcat.Rx0 = [zeros(size(a,1),b.dim(1,2)); b.Rx0];
+%                     Pcat.Rxx{1,1} = [a; b.Rxx{1,1}];
+%                     Pcat.Rxx{2,1} = [zeros(size(a,1),b.dim(2,2)); b.Rxx{2,1}];
+%                     Pcat.Rxx{3,1} = [zeros(size(a,1),b.dim(2,2)); b.Rxx{3,1}];
+%                     Pcat.Rxy = [zeros(size(a,1),b.dim(3,2)); b.Rxy];
+%                     Pcat.Rx2{1,1} = [zeros(size(a,1),b.dim(4,2)); b.Rx2{1,1}];
+%                     Pcat.Rx2{2,1} = [zeros(size(a,1),b.dim(4,2)); b.Rx2{2,1}];
+%                     Pcat.Rx2{3,1} = [zeros(size(a,1),b.dim(4,2)); b.Rx2{3,1}];
+%                 elseif all(bdim([1:2,4],2) == 0) % a() is from L2[s2] to L2[s2], Note: For L2 to R, a must be opvar2d 
+%                     Pcat.Ry0 = [zeros(size(a,1),b.dim(1,2)); b.Ry0];
+%                     Pcat.Ryx = [zeros(size(a,1),b.dim(2,2)); b.Ryx];
+%                     Pcat.Ryy{1,1} = [a; b.Ryy{1,1}];
+%                     Pcat.Ryy{1,2} = [zeros(size(a,1),b.dim(3,2)); b.Ryy{1,2}];
+%                     Pcat.Ryy{1,3} = [zeros(size(a,1),b.dim(3,2)); b.Ryy{1,3}];
+%                     Pcat.Ry2{1,1} = [zeros(size(a,1),b.dim(4,2)); b.Ry2{1,1}];
+%                     Pcat.Ry2{1,2} = [zeros(size(a,1),b.dim(4,2)); b.Ry2{1,2}];
+%                     Pcat.Ry2{1,3} = [zeros(size(a,1),b.dim(4,2)); b.Ry2{1,3}];
+%                 elseif all(bdim(1:3,2) == 0) % a() is from L2[s1,s2] to L2[s1,s2], Note: For L2 to R, a must be opvar2d 
+%                     Pcat.R20 = [zeros(size(a,1),b.dim(1,2)); b.R20];
+%                     Pcat.R2x{1,1} = [zeros(size(a,1),b.dim(2,2)); b.R2x{1,1}];
+%                     Pcat.R2x{2,1} = [zeros(size(a,1),b.dim(2,2)); b.R2x{2,1}];
+%                     Pcat.R2x{3,1} = [zeros(size(a,1),b.dim(2,2)); b.R2x{3,1}];
+%                     Pcat.R2y{1,1} = [zeros(size(a,1),b.dim(3,2)); b.R2y{1,1}];
+%                     Pcat.R2y{1,2} = [zeros(size(a,1),b.dim(3,2)); b.R2y{1,2}];
+%                     Pcat.R2y{1,3} = [zeros(size(a,1),b.dim(3,2)); b.R2y{1,3}];
+%                     Pcat.R22{1,1} = [a; b.R22{1,1}];
+%                     Pcat.R22{2,1} = [zeros(size(a,1),b.dim(4,2)); b.R22{2,1}];
+%                     Pcat.R22{3,1} = [zeros(size(a,1),b.dim(4,2)); b.R22{3,1}];
+%                     Pcat.R22{1,2} = [zeros(size(a,1),b.dim(4,2)); b.R22{1,2}];
+%                     Pcat.R22{2,2} = [zeros(size(a,1),b.dim(4,2)); b.R22{2,2}];
+%                     Pcat.R22{3,2} = [zeros(size(a,1),b.dim(4,2)); b.R22{3,2}];
+%                     Pcat.R22{1,3} = [zeros(size(a,1),b.dim(4,2)); b.R22{1,3}];
+%                     Pcat.R22{2,3} = [zeros(size(a,1),b.dim(4,2)); b.R22{2,3}];
+%                     Pcat.R22{3,3} = [zeros(size(a,1),b.dim(4,2)); b.R22{3,3}];
+%                 else %find if such an operation is valid in any useful scenario and implement it
+%                     error('Cannot concatenate vertically. This feature is not yet supported.');
+%                 end
+%             end
+%         end
+%     elseif ~isa(b,'opvar2d') 
+%         adim = a.dim;
+%         if size(b,2)~=sum(adim(:,2))
+%             error("Cannot concatentate vertically. A and B have different input dimensions");
+%         end
+%         Pcat = a;
+%         Pcat.dim = [a.dim(:,1)+(a.dim(:,1)~=0).*size(b,1),a.dim(:,2)];
+%         if ~isempty(b)
+%             if all(adim(2:4,2) == 0) % b() is from R to R
+%                 Pcat.R00 = [a.R00; b]; 
+%                 Pcat.R0x = [a.R0x; zeros(size(b,1),a.dim(2,2))];
+%                 Pcat.R0y = [a.R0y; zeros(size(b,1),a.dim(3,2))];
+%                 Pcat.R02 = [a.R02; zeros(size(b,1),a.dim(4,2))];
+%             elseif all(adim([1,3:4],2) == 0) % b() is from L2[s1] to L2[s1]
+%                 Pcat.Rx0 = [a.Rx0; zeros(size(b,1),a.dim(1,2))];
+%                 Pcat.Rxx{1,1} = [a.Rxx{1,1}; b];
+%                 Pcat.Rxx{2,1} = [a.Rxx{2,1}; zeros(size(b,1),a.dim(2,2))];
+%                 Pcat.Rxx{3,1} = [a.Rxx{3,1}; zeros(size(b,1),a.dim(2,2))];
+%                 Pcat.Rxy = [a.Rxy; zeros(size(b,1),a.dim(3,2))];
+%                 Pcat.Rx2{1,1} = [a.Rx2{1,1}; zeros(size(b,1),a.dim(4,2))];
+%                 Pcat.Rx2{2,1} = [a.Rx2{2,1}; zeros(size(b,1),a.dim(4,2))];
+%                 Pcat.Rx2{3,1} = [a.Rx2{3,1}; zeros(size(b,1),a.dim(4,2))];
+%             elseif all(adim([1:2,4],2) == 0) % b() is from L2[s2] to L2[s2]
+%                 Pcat.Ry0 = [a.Ry0; zeros(size(b,1),a.dim(1,2))];
+%                 Pcat.Ryx = [a.Ryx; zeros(size(b,1),a.dim(2,2))];
+%                 Pcat.Ryy{1,1} = [a.Ryy{1,1}; b];
+%                 Pcat.Ryy{1,2} = [a.Ryy{1,2}; zeros(size(b,1),a.dim(3,2))];
+%                 Pcat.Ryy{1,3} = [a.Ryy{1,3}; zeros(size(b,1),a.dim(3,2))];
+%                 Pcat.Ry2{1,1} = [a.Ry2{1,1}; zeros(size(b,1),a.dim(4,2))];
+%                 Pcat.Ry2{1,2} = [a.Ry2{1,2}; zeros(size(b,1),a.dim(4,2))];
+%                 Pcat.Ry2{1,3} = [a.Ry2{1,3}; zeros(size(b,1),a.dim(4,2))];
+%             elseif all(adim(1:3,2) == 0) % b() is from L2[s1,s2] to L2[s1,s2]
+%                 Pcat.R20 = [a.R20; zeros(size(b,1),a.dim(1,2))];
+%                 Pcat.R2x{1,1} = [a.R2x{1,1}; zeros(size(b,1),a.dim(2,2))];
+%                 Pcat.R2x{2,1} = [a.R2x{2,1}; zeros(size(b,1),a.dim(2,2))];
+%                 Pcat.R2x{3,1} = [a.R2x{3,1}; zeros(size(b,1),a.dim(2,2))];
+%                 Pcat.R2y{1,1} = [a.R2y{1,1}; zeros(size(b,1),a.dim(3,2))];
+%                 Pcat.R2y{1,2} = [a.R2y{1,2}; zeros(size(b,1),a.dim(3,2))];
+%                 Pcat.R2y{1,3} = [a.R2y{1,3}; zeros(size(b,1),a.dim(3,2))];
+%                 Pcat.R22{1,1} = [a.R22{1,1}; b];
+%                 Pcat.R22{2,1} = [a.R22{2,1}; zeros(size(b,1),a.dim(4,2))];
+%                 Pcat.R22{3,1} = [a.R22{3,1}; zeros(size(b,1),a.dim(4,2))];
+%                 Pcat.R22{1,2} = [a.R22{1,2}; zeros(size(b,1),a.dim(4,2))];
+%                 Pcat.R22{2,2} = [a.R22{2,2}; zeros(size(b,1),a.dim(4,2))];
+%                 Pcat.R22{3,2} = [a.R22{3,2}; zeros(size(b,1),a.dim(4,2))];
+%                 Pcat.R22{1,3} = [a.R22{1,3}; zeros(size(b,1),a.dim(4,2))];
+%                 Pcat.R22{2,3} = [a.R22{2,3}; zeros(size(b,1),a.dim(4,2))];
+%                 Pcat.R22{3,3} = [a.R22{3,3}; zeros(size(b,1),a.dim(4,2))];
+%             else %find if such an operation is valid in any useful scenario and implement it
+%                 error('Cannot concatenate vertically. This feature is not yet supported.');
+%             end
+%         end
+%     else
+%         if any(b.dim(:,2)~=a.dim(:,2))
+%             error('Cannot concatentate horizontally. A and B have different column dimensions');
+%         elseif any(any(b.I~=a.I))
+%             error('Cannot concatentate horizontally: A and B have different domains');
+%         end
+%         % Initialize the concatenated operator
+%         newdim = [a.dim(:,1)+b.dim(:,1),a.dim(:,2)];
+%         Pcat = opvar2d([],newdim,a.I,a.var1,a.var2);
+%         
+%         % Only concatenate columns which are nonempty
+%         fset = {};
+%         c = zeros(4,1);
+%         if Pcat.dim(1,2)~=0
+%             fset = [fset,'R00','Rx0','Ry0','R20'];
+%             c(1) = 1;
+%         end
+%         if Pcat.dim(2,2)~=0
+%             fset = [fset,'R0x','Ryx'];
+%             c(2) = 1;
+%         end
+%         if Pcat.dim(3,2)~=0
+%             fset = [fset,'R0y','Rxy'];
+%             c(3) = 1;
+%         end
+%         if Pcat.dim(4,2)~=0
+%             fset = [fset,'R02'];
+%             c(4) = 1;
+%         end
+%         
+%         % Perform the concatenation
+%         for f=fset
+%             Pcat.(f{:}) = [a.(f{:}); b.(f{:})];
+%         end
+%         for i=1:3
+%             if c(2)
+%                 Pcat.Rxx{i,1} = [a.Rxx{i,1}; b.Rxx{i,1}];
+%                 Pcat.R2x{i,1} = [a.R2x{i,1}; b.R2x{i,1}];
+%             end
+%             if c(3)
+%                 Pcat.Ryy{1,i} = [a.Ryy{1,i}; b.Ryy{1,i}];
+%                 Pcat.R2y{1,i} = [a.R2y{1,i}; b.R2y{1,i}];
+%             end
+%             if c(4)
+%                 Pcat.Rx2{i,1} = [a.Rx2{i,1}; b.Rx2{i,1}];
+%                 Pcat.Ry2{1,i} = [a.Ry2{1,i}; b.Ry2{1,i}];
+%                 for j=1:3
+%                     Pcat.R22{i,j} = [a.R22{i,j}; b.R22{i,j}];
+%                 end
+%             end
+%         end
+%     end
+%     if nargin>2 % Continue concatenation if inputs are more than 2
+%         Pcat = vertcat(Pcat, varargin{3:end});
+%     end
+% end
+% end

--- a/PIETOOLS/opvar/@dopvar/horzcat.m
+++ b/PIETOOLS/opvar/@dopvar/horzcat.m
@@ -1,12 +1,15 @@
 function [Pcat] = horzcat(varargin) 
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
-% [Pcat] = horzcat(varargin) takes n-inputs and concatentates them horizontally,
-% provided they satisfy the following criterias.
-% 1) Atleast one input is an dopvar variable.
-% 2) If all the inputs are not dopvar, then the operator maps from RxL2 to
-%    L2 or R to R. 
-% 3) Currently, it supports RxL2 to RxL2 concatenation only if ALL the inputs are
-%    opvar.
+% [Pcat] = horzcat(varargin) takes n inputs and concatentates them horizontally,
+% provided they satisfy the following criteria:
+% 1) At least one input must be of type 'dopvar', and all others must be of
+%       type 'opvar' or 'dopvar';
+% 2) The output dimensions varargin{j}.dim(:,1) of all objects must match;
+% 3) The spatial variables varargin{j}.var1 and varargin{j}.var2, as well 
+%       as the domain varargin{j}.I of all objects must match;
+% 4) Concatenation should make sense within the context of the opvar class,
+%       that is, opvars take inputs from RxL2, never from L2xR. We cannot
+%       concatenate e.g. [A,B] for A:L2-->R and B:R-->R.
 % 
 % NOTES:
 % For support, contact M. Peet, Arizona State University at mpeet@asu.edu
@@ -43,111 +46,178 @@ function [Pcat] = horzcat(varargin)
 % SS - 9/26/2021 adding bug fixes to when concatenation has elements that
 % are polynomials or just opvars
 % DJ - 12/30/2021 Adjusted to assure opvar with dopvar returns dopvar
+% DJ - 09/30/23: Prohibit "ambiguous" concatenations.
 
-
+% Deal with single input case
 if nargin==1
     Pcat = varargin{1};
-else
-    a = varargin{1};
-    b = varargin{2};
-    
-    if isa(a,'dopvar') % correction to make components have consistent dimensions 8/27-ss
-        a.dim = a.dim;
-    end
-    if isa(b,'dopvar') % correction to make components have consistent dimensions 8/27-ss
-        b.dim = b.dim;
-    end
-    
-    dopvar Pcat;
-    if isa(a,'dopvar')
-        Pcat.I = a.I; Pcat.var1 = a.var1; Pcat.var2 = a.var2;
-    elseif isa(b,'dopvar')
-        Pcat.I = b.I; Pcat.var1 = b.var1; Pcat.var2 = b.var2;
-    elseif isa(a,'dopvar')&&isa(b,'dopvar')
-        if any(a.I~=b.I)||(a.var1~=b.var1)||(a.var2~=b.var2)
-            error('Operators being concatenated have different intervals or different independent variables');
-        end
-    end
-    
-    if ~isa(a,'dopvar')
-        if ~isa(b,'dopvar') % both are not dopvar type variables
-            Pcat = [a b];
-        elseif ~isa(a,'opvar')&&b.dim(1,1)==0 % a() is from R to L2, Note: L2 to L2 needs to be an opvar
-            if size(a,1)~=b.dim(2,1) 
-                error('Cannot concatentate horizontally. A and B have different output dimensions');
-            end 
-%             Pcat = b;
-            Pcat.Q2 = [a b.Q2];
-            Pcat.P = [zeros(b.dim(1,1),size(a,2)) b.P];
-        elseif ~isa(a,'opvar')&&b.dim(2,1)==0 % a() is from R to R, Note: L2 to R needs to be an opvar
-            if size(a,1)~=b.dim(1,1) 
-                error('Cannot concatentate horizontally. A and B have different output dimensions');
-            end
-%             Pcat = b;
-            Pcat.P = [a b.P];
-            Pcat.Q2 = [zeros(b.dim(2,1),size(a,2)) b.Q2];
-        else
-        if any(b.dim(:,1)~=a.dim(:,1))
-            error('Cannot concatentate horizontally. A and B have different output dimensions');
-        end
-%         Pcat = b;
-        fset = {'P', 'Q1', 'Q2'};
-
-        for i=fset
-            Pcat.(i{:}) = [a.(i{:}) b.(i{:})];
-        end
-        fset = {'R0','R1','R2'};
-        for i=fset
-            Pcat.R.(i{:}) = [a.R.(i{:}) b.R.(i{:})];
-        end
-        end
-    elseif ~isa(b,'dopvar')
-        if ~isa(b,'opvar')&&a.dim(1,1)==0 % b() is from R to L2, Note: L2 to L2 needs to be an opvar
-            if size(b,1)~=a.dim(2,1) 
-                error('Cannot concatentate horizontally. A and B have different output dimensions');
-            end
-%             Pcat = a;
-            Pcat.Q2 = [a.Q2 b];
-            Pcat.P = [a.P zeros(a.dim(1,1),size(b,2))];
-        elseif ~isa(b,'opvar')&&a.dim(2,1)==0 % b() is from R to R, Note: L2 to R needs to be an opvar
-            if size(b,1)~=a.dim(1,1) 
-                error('Cannot concatentate horizontally. A and B have different output dimensions');
-            end
-%             Pcat = a;
-            Pcat.P = [a.P b];
-            Pcat.Q2 = [a.Q2 zeros(a.dim(2,1),size(b,2))];
-        else
-        if any(b.dim(:,1)~=a.dim(:,1))
-            error('Cannot concatentate horizontally. A and B have different output dimensions');
-        end
-%         Pcat = a;
-        fset = {'P', 'Q1', 'Q2'};
-
-        for i=fset
-            Pcat.(i{:}) = [a.(i{:}) b.(i{:})];
-        end
-        fset = {'R0','R1','R2'};
-        for i=fset
-            Pcat.R.(i{:}) = [a.R.(i{:}) b.R.(i{:})];
-        end
-        end
-    else
-        if any(b.dim(:,1)~=a.dim(:,1))
-            error('Cannot concatentate horizontally. A and B have different output dimensions');
-        end
-%         Pcat = a;
-        fset = {'P', 'Q1', 'Q2'};
-
-        for i=fset
-            Pcat.(i{:}) = [a.(i{:}) b.(i{:})];
-        end
-        fset = {'R0','R1','R2'};
-        for i=fset
-            Pcat.R.(i{:}) = [a.R.(i{:}) b.R.(i{:})];
-        end
-    end
-    if nargin>2 % check if there are more than 2 objects that need to stacked
-        Pcat = horzcat(Pcat, varargin{3:end});
-    end
+    return
 end
+
+% Extract the operators
+a = varargin{1};    b = varargin{2};
+
+% Currently support only opvar-opvar concatenation
+if (~isa(a,'opvar') && ~isa(a,'dopvar')) || (~isa(b,'opvar') && ~isa(b,'dopvar'))
+    error('dopvar  objects can only be concatenated with opvar and dopvar objects')
 end
+% Check that domain and variables match
+if any(a.I~=b.I)|| ~strcmp(a.var1.varname,b.var1.varname) || ~strcmp(a.var2.varname,b.var2.varname)
+    error('Operators being concatenated have different intervals or different independent variables');
+end
+% Check that the output dimensions match
+a.dim = a.dim;  b.dim = b.dim;  % correction to make components have consistent dimensions 8/27-ss
+if any(a.dim(:,1)~=b.dim(:,1))
+    error('Cannot concatenate horizontally: Output dimensions of opvar objects do not match')
+end
+
+% Avoid "ambiguous" concatenations
+if (a.dim(2,2)~=0 && b.dim(1,2)~=0)
+    % a has columns mapping from L2, but b has columns mapping from R.
+    % Concatenation would place those columns of a to the right of
+    % those columns of b in the opvar, which we currently prohibit...
+    error('Proposed opvar concatenation is ambiguous, and currently prohibited')
+end
+
+% Finally, let's actually concatenate
+dopvar Pcat;
+Pcat.I = a.I;   Pcat.var1 = a.var1;     Pcat.var2 = a.var2;
+fset = {'P', 'Q1', 'Q2'};
+for i=fset
+    Pcat.(i{:}) = [a.(i{:}) b.(i{:})];
+end
+fset = {'R0','R1','R2'};
+for i=fset
+    Pcat.R.(i{:}) = [a.R.(i{:}) b.R.(i{:})];
+end
+
+% For concatenation of more than two objects, just repeat
+if nargin>2 
+    Pcat = horzcat(Pcat, varargin{3:end});
+end
+
+end
+
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+%%%%%%%%%%  Old version, that allows "ambiguous" concatenation   %%%%%%%%%%
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+% [Pcat] = horzcat(varargin) takes n-inputs and concatentates them horizontally,
+% provided they satisfy the following criteria:
+% 1) Atleast one input is an dopvar variable.
+% 2) If all the inputs are not dopvar, then the operator maps from RxL2 to
+%    L2 or R to R. 
+% 3) Currently, it supports RxL2 to RxL2 concatenation only if ALL the inputs are
+%    opvar.
+% 
+% NOTES:
+% For support, contact M. Peet, Arizona State University at mpeet@asu.edu
+% or S. Shivakumar at sshivak8@asu.edu
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+%
+% if nargin==1
+%     Pcat = varargin{1};
+% else
+%     a = varargin{1};
+%     b = varargin{2};
+%     
+%     if isa(a,'dopvar') % correction to make components have consistent dimensions 8/27-ss
+%         a.dim = a.dim;
+%     end
+%     if isa(b,'dopvar') % correction to make components have consistent dimensions 8/27-ss
+%         b.dim = b.dim;
+%     end
+%     
+%     dopvar Pcat;
+%     if isa(a,'dopvar')
+%         Pcat.I = a.I; Pcat.var1 = a.var1; Pcat.var2 = a.var2;
+%     elseif isa(b,'dopvar')
+%         Pcat.I = b.I; Pcat.var1 = b.var1; Pcat.var2 = b.var2;
+%     elseif isa(a,'dopvar')&&isa(b,'dopvar')
+%         if any(a.I~=b.I)||(a.var1~=b.var1)||(a.var2~=b.var2)
+%             error('Operators being concatenated have different intervals or different independent variables');
+%         end
+%     end
+%     
+%     if ~isa(a,'dopvar')
+%         if ~isa(b,'dopvar') % both are not dopvar type variables
+%             Pcat = [a b];
+%         elseif ~isa(a,'opvar')&&b.dim(1,1)==0 % a() is from R to L2, Note: L2 to L2 needs to be an opvar
+%             if size(a,1)~=b.dim(2,1) 
+%                 error('Cannot concatentate horizontally. A and B have different output dimensions');
+%             end 
+% %             Pcat = b;
+%             Pcat.Q2 = [a b.Q2];
+%             Pcat.P = [zeros(b.dim(1,1),size(a,2)) b.P];
+%         elseif ~isa(a,'opvar')&&b.dim(2,1)==0 % a() is from R to R, Note: L2 to R needs to be an opvar
+%             if size(a,1)~=b.dim(1,1) 
+%                 error('Cannot concatentate horizontally. A and B have different output dimensions');
+%             end
+% %             Pcat = b;
+%             Pcat.P = [a b.P];
+%             Pcat.Q2 = [zeros(b.dim(2,1),size(a,2)) b.Q2];
+%         else
+%         if any(b.dim(:,1)~=a.dim(:,1))
+%             error('Cannot concatentate horizontally. A and B have different output dimensions');
+%         end
+% %         Pcat = b;
+%         fset = {'P', 'Q1', 'Q2'};
+% 
+%         for i=fset
+%             Pcat.(i{:}) = [a.(i{:}) b.(i{:})];
+%         end
+%         fset = {'R0','R1','R2'};
+%         for i=fset
+%             Pcat.R.(i{:}) = [a.R.(i{:}) b.R.(i{:})];
+%         end
+%         end
+%     elseif ~isa(b,'dopvar')
+%         if ~isa(b,'opvar')&&a.dim(1,1)==0 % b() is from R to L2, Note: L2 to L2 needs to be an opvar
+%             if size(b,1)~=a.dim(2,1) 
+%                 error('Cannot concatentate horizontally. A and B have different output dimensions');
+%             end
+% %             Pcat = a;
+%             Pcat.Q2 = [a.Q2 b];
+%             Pcat.P = [a.P zeros(a.dim(1,1),size(b,2))];
+%         elseif ~isa(b,'opvar')&&a.dim(2,1)==0 % b() is from R to R, Note: L2 to R needs to be an opvar
+%             if size(b,1)~=a.dim(1,1) 
+%                 error('Cannot concatentate horizontally. A and B have different output dimensions');
+%             end
+% %             Pcat = a;
+%             Pcat.P = [a.P b];
+%             Pcat.Q2 = [a.Q2 zeros(a.dim(2,1),size(b,2))];
+%         else
+%         if any(b.dim(:,1)~=a.dim(:,1))
+%             error('Cannot concatentate horizontally. A and B have different output dimensions');
+%         end
+% %         Pcat = a;
+%         fset = {'P', 'Q1', 'Q2'};
+% 
+%         for i=fset
+%             Pcat.(i{:}) = [a.(i{:}) b.(i{:})];
+%         end
+%         fset = {'R0','R1','R2'};
+%         for i=fset
+%             Pcat.R.(i{:}) = [a.R.(i{:}) b.R.(i{:})];
+%         end
+%         end
+%     else
+%         if any(b.dim(:,1)~=a.dim(:,1))
+%             error('Cannot concatentate horizontally. A and B have different output dimensions');
+%         end
+% %         Pcat = a;
+%         fset = {'P', 'Q1', 'Q2'};
+% 
+%         for i=fset
+%             Pcat.(i{:}) = [a.(i{:}) b.(i{:})];
+%         end
+%         fset = {'R0','R1','R2'};
+%         for i=fset
+%             Pcat.R.(i{:}) = [a.R.(i{:}) b.R.(i{:})];
+%         end
+%     end
+%     if nargin>2 % check if there are more than 2 objects that need to stacked
+%         Pcat = horzcat(Pcat, varargin{3:end});
+%     end
+% end

--- a/PIETOOLS/opvar/@dopvar/vertcat.m
+++ b/PIETOOLS/opvar/@dopvar/vertcat.m
@@ -1,12 +1,15 @@
 function [Pcat] = vertcat(varargin)
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
-% [Pcat] = vertcat(varargin) takes n-inputs and concatentates them vertically,
-% provided they satisfy the following criterias.
-% 1) Atleast one input is an dopvar variable.
-% 2) If all the inputs are not dopvar, then the operator maps from R to
-% RxL2 or L2 to L2. 
-% 3) Currently, it supports RxL2 to RxL2 concatenation only if ALL the inputs are
-% opvar.
+% [Pcat] = vertcat(varargin) takes n inputs and concatentates them vertically,
+% provided they satisfy the following criteria:
+% 1) At least one input must be of type 'dopvar', and all others must be of
+%       type 'opvar' or 'dopvar';
+% 2) The input dimensions varargin{j}.dim(:,2) of all objects must match;
+% 3) The spatial variables varargin{j}.var1 and varargin{j}.var2, as well 
+%       as the domain varargin{j}.I of all objects must match;
+% 4) Concatenation should make sense within the context of the opvar class,
+%       that is, opvars always mapt to from RxL2, never to L2xR. We cannot
+%       concatenate e.g. [A;B] for A:R-->L2 and B:R-->R.
 %
 % NOTES:
 % For support, contact M. Peet, Arizona State University at mpeet@asu.edu
@@ -38,108 +41,176 @@ function [Pcat] = vertcat(varargin)
 %
 % DJ, 09/29/2021: Small adjustment to avoid error with dopvar-opvar concatenation
 % DJ, 12/30/2021: Adjusted to assure opvar with dopvar returns dopvar
+% DJ - 09/30/23: Prohibit "ambiguous" concatenations.
 
-
+% Deal with single input case
 if nargin==1
     Pcat = varargin{1};
-else
-    a = varargin{1};
-    b = varargin{2};
-    
-    if isa(a,'dopvar') % correction to make components have consistent dimensions 8/27-ss
-        a.dim = a.dim;
-    end
-    if isa(b,'dopvar') % correction to make components have consistent dimensions 8/27-ss
-        b.dim = b.dim;
-    end
-    
-    dopvar Pcat;
-    if isa(a,'dopvar')
-        Pcat.I = a.I; Pcat.var1 = a.var1; Pcat.var2 = a.var2;
-    elseif isa(b,'dopvar')
-        Pcat.I = b.I; Pcat.var1 = b.var1; Pcat.var2 = b.var2;
-    elseif isa(a,'dopvar')&&isa(b,'dopvar')
-        if any(a.I~=b.I)||(a.var1~=b.var1)||(a.var2~=b.var2)
-            error('Operators being concatenated have different intervals or different independent variables');
-        end
-    end
-    
-    if ~isa(a,'dopvar')
-        if ~isa(b,'dopvar')
-            Pcat = [a;b];
-        else
-            bdim = b.dim;
-            if ~isa(a,'opvar') && size(a,2)~=sum(bdim(:,2)) % DJ 09/29/2021
-                error("Cannot concatentate vertically. A and B have different input dimensions");
-            end
-%             Pcat = b;
-            if bdim(2,2) ==0 && ~isa(a,'opvar')
-                Pcat.P = [a; b.P]; % a() is from R to R
-                Pcat.Q1 =[zeros(size(a,1),b.dim(2,2)); b.Q1];
-            elseif bdim(1,2)==0 && ~isa(a,'opvar')% a() is from L2 to L2, Note: a() cannot be a matrix and map L2 to R 
-                Pcat.Q2 = [zeros(size(a,1),b.dim(1,2)); b.Q2];
-                Pcat.R.R0 = [a; b.R.R0];
-                Pcat.R.R1 = [zeros(size(a)); b.R.R1];
-                Pcat.R.R2 = [zeros(size(a)); b.R.R2];
-            else %find if such a operation is valid is any useful scenario and implement it
-                if any(b.dim(:,2)~=a.dim(:,2))
-                    error("Cannot concatentate vertically. A and B have different input dimensions");
-                end
-%         Pcat = b;
-        fset = {'P', 'Q1', 'Q2'};
-        for i=fset
-            Pcat.(i{:}) = [a.(i{:}); b.(i{:})];
-        end
-        fset = {'R0','R1','R2'};
-        for i=fset
-            Pcat.R.(i{:}) = [a.R.(i{:}); b.R.(i{:})];
-        end
-            end
-        end
-    elseif ~isa(b,'dopvar')
-        adim = a.dim;
-        if ~isa(b,'opvar') && size(b,2)~=sum(adim(:,2)) % DJ 09/29/2021
-            error("Cannot concatentate vertically. A and B have different input dimensions");
-        end
-%         Pcat = a;
-        if adim(2,2) ==0&& ~isa(b,'opvar')
-            Pcat.P = [a.P; b]; % b() is from R to R
-            Pcat.Q1 = [a.Q1; zeros(size(b,1),a.dim(2,2))];
-        elseif adim(1,2)==0 && ~isa(b,'opvar')% b() is from L2 to L2, Note: b() cannot be L2 to R and not be opvar
-            Pcat.Q2 = [a.Q2; zeros(size(b,1),a.dim(1,2))];
-            Pcat.R.R0 = [a.R.R0; b];
-            Pcat.R.R1 = [a.R.R1; zeros(size(b))];
-            Pcat.R.R2 = [a.R.R2; zeros(size(b))];
-        else %find if such a operation is valid is any useful scenario and implement it
-            if any(b.dim(:,2)~=a.dim(:,2))
-                error("Cannot concatentate vertically. A and B have different input dimensions");
-            end
-%         Pcat = a;
-        fset = {'P', 'Q1', 'Q2'};
-        for i=fset
-            Pcat.(i{:}) = [a.(i{:}); b.(i{:})];
-        end
-        fset = {'R0','R1','R2'};
-        for i=fset
-            Pcat.R.(i{:}) = [a.R.(i{:}); b.R.(i{:})];
-        end
-        end
-    else
-        if any(b.dim(:,2)~=a.dim(:,2))
-            error("Cannot concatentate vertically. A and B have different input dimensions");
-        end
-%         Pcat = a;
-        fset = {'P', 'Q1', 'Q2'};
-        for i=fset
-            Pcat.(i{:}) = [a.(i{:}); b.(i{:})];
-        end
-        fset = {'R0','R1','R2'};
-        for i=fset
-            Pcat.R.(i{:}) = [a.R.(i{:}); b.R.(i{:})];
-        end
-    end
-    if nargin>2 % Continue concatenation if inputs are more than 2
-        Pcat = vertcat(Pcat, varargin{3:end});
-    end
+    return
 end
+
+% Extract the operators
+a = varargin{1};    b = varargin{2};
+
+% Currently support only opvar-opvar concatenation
+if (~isa(a,'opvar') && ~isa(a,'dopvar')) || (~isa(b,'opvar') && ~isa(b,'dopvar'))
+    error('dopvar  objects can only be concatenated with opvar and dopvar objects')
 end
+% Check that domain and variables match
+if any(a.I~=b.I)|| ~strcmp(a.var1.varname,b.var1.varname) || ~strcmp(a.var2.varname,b.var2.varname)
+    error('Operators being concatenated have different intervals or different independent variables');
+end
+% Check that the output dimensions match
+a.dim = a.dim;  b.dim = b.dim;  % correction to make components have consistent dimensions 8/27-ss
+if any(a.dim(:,2)~=b.dim(:,2))
+    error('Cannot concatenate vertically: Input dimensions of opvar objects do not match')
+end
+
+% Avoid "ambiguous" concatenations
+if (a.dim(2,1)~=0 && b.dim(1,1)~=0)
+    % a has rows mapping to L2, but b has rows mapping to R.
+    % Concatenation would place those rows of a below those of b in the
+    % opvar, which we currently prohibit...
+    error('Proposed opvar concatenation is ambiguous, and currently prohibited')
+end
+
+% Finally, let's actually concatenate
+dopvar Pcat;
+Pcat.I = a.I;   Pcat.var1 = a.var1;     Pcat.var2 = a.var2;
+fset = {'P', 'Q1', 'Q2'};
+for i=fset
+    Pcat.(i{:}) = [a.(i{:}); b.(i{:})];
+end
+fset = {'R0','R1','R2'};
+for i=fset
+    Pcat.R.(i{:}) = [a.R.(i{:}); b.R.(i{:})];
+end
+
+% For concatenation of more than two objects, just repeat
+if nargin>2 
+    Pcat = vertcat(Pcat, varargin{3:end});
+end
+
+end
+
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+%%%%%%%%%%  Old version, that allows "ambiguous" concatenation   %%%%%%%%%%
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+% [Pcat] = vertcat(varargin) takes n-inputs and concatentates them vertically,
+% provided they satisfy the following criterias.
+% 1) Atleast one input is an dopvar variable.
+% 2) If all the inputs are not dopvar, then the operator maps from R to
+% RxL2 or L2 to L2. 
+% 3) Currently, it supports RxL2 to RxL2 concatenation only if ALL the inputs are
+% opvar.
+%
+% NOTES:
+% For support, contact M. Peet, Arizona State University at mpeet@asu.edu
+% or S. Shivakumar at sshivak8@asu.edu
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+%
+% if nargin==1
+%     Pcat = varargin{1};
+% else
+%     a = varargin{1};
+%     b = varargin{2};
+%     
+%     if isa(a,'dopvar') % correction to make components have consistent dimensions 8/27-ss
+%         a.dim = a.dim;
+%     end
+%     if isa(b,'dopvar') % correction to make components have consistent dimensions 8/27-ss
+%         b.dim = b.dim;
+%     end
+%     
+%     dopvar Pcat;
+%     if isa(a,'dopvar')
+%         Pcat.I = a.I; Pcat.var1 = a.var1; Pcat.var2 = a.var2;
+%     elseif isa(b,'dopvar')
+%         Pcat.I = b.I; Pcat.var1 = b.var1; Pcat.var2 = b.var2;
+%     elseif isa(a,'dopvar')&&isa(b,'dopvar')
+%         if any(a.I~=b.I)||(a.var1~=b.var1)||(a.var2~=b.var2)
+%             error('Operators being concatenated have different intervals or different independent variables');
+%         end
+%     end
+%     
+%     if ~isa(a,'dopvar')
+%         if ~isa(b,'dopvar')
+%             Pcat = [a;b];
+%         else
+%             bdim = b.dim;
+%             if ~isa(a,'opvar') && size(a,2)~=sum(bdim(:,2)) % DJ 09/29/2021
+%                 error("Cannot concatentate vertically. A and B have different input dimensions");
+%             end
+% %             Pcat = b;
+%             if bdim(2,2) ==0 && ~isa(a,'opvar')
+%                 Pcat.P = [a; b.P]; % a() is from R to R
+%                 Pcat.Q1 =[zeros(size(a,1),b.dim(2,2)); b.Q1];
+%             elseif bdim(1,2)==0 && ~isa(a,'opvar')% a() is from L2 to L2, Note: a() cannot be a matrix and map L2 to R 
+%                 Pcat.Q2 = [zeros(size(a,1),b.dim(1,2)); b.Q2];
+%                 Pcat.R.R0 = [a; b.R.R0];
+%                 Pcat.R.R1 = [zeros(size(a)); b.R.R1];
+%                 Pcat.R.R2 = [zeros(size(a)); b.R.R2];
+%             else %find if such a operation is valid is any useful scenario and implement it
+%                 if any(b.dim(:,2)~=a.dim(:,2))
+%                     error("Cannot concatentate vertically. A and B have different input dimensions");
+%                 end
+% %         Pcat = b;
+%         fset = {'P', 'Q1', 'Q2'};
+%         for i=fset
+%             Pcat.(i{:}) = [a.(i{:}); b.(i{:})];
+%         end
+%         fset = {'R0','R1','R2'};
+%         for i=fset
+%             Pcat.R.(i{:}) = [a.R.(i{:}); b.R.(i{:})];
+%         end
+%             end
+%         end
+%     elseif ~isa(b,'dopvar')
+%         adim = a.dim;
+%         if ~isa(b,'opvar') && size(b,2)~=sum(adim(:,2)) % DJ 09/29/2021
+%             error("Cannot concatentate vertically. A and B have different input dimensions");
+%         end
+% %         Pcat = a;
+%         if adim(2,2) ==0&& ~isa(b,'opvar')
+%             Pcat.P = [a.P; b]; % b() is from R to R
+%             Pcat.Q1 = [a.Q1; zeros(size(b,1),a.dim(2,2))];
+%         elseif adim(1,2)==0 && ~isa(b,'opvar')% b() is from L2 to L2, Note: b() cannot be L2 to R and not be opvar
+%             Pcat.Q2 = [a.Q2; zeros(size(b,1),a.dim(1,2))];
+%             Pcat.R.R0 = [a.R.R0; b];
+%             Pcat.R.R1 = [a.R.R1; zeros(size(b))];
+%             Pcat.R.R2 = [a.R.R2; zeros(size(b))];
+%         else %find if such a operation is valid is any useful scenario and implement it
+%             if any(b.dim(:,2)~=a.dim(:,2))
+%                 error("Cannot concatentate vertically. A and B have different input dimensions");
+%             end
+% %         Pcat = a;
+%         fset = {'P', 'Q1', 'Q2'};
+%         for i=fset
+%             Pcat.(i{:}) = [a.(i{:}); b.(i{:})];
+%         end
+%         fset = {'R0','R1','R2'};
+%         for i=fset
+%             Pcat.R.(i{:}) = [a.R.(i{:}); b.R.(i{:})];
+%         end
+%         end
+%     else
+%         if any(b.dim(:,2)~=a.dim(:,2))
+%             error("Cannot concatentate vertically. A and B have different input dimensions");
+%         end
+% %         Pcat = a;
+%         fset = {'P', 'Q1', 'Q2'};
+%         for i=fset
+%             Pcat.(i{:}) = [a.(i{:}); b.(i{:})];
+%         end
+%         fset = {'R0','R1','R2'};
+%         for i=fset
+%             Pcat.R.(i{:}) = [a.R.(i{:}); b.R.(i{:})];
+%         end
+%     end
+%     if nargin>2 % Continue concatenation if inputs are more than 2
+%         Pcat = vertcat(Pcat, varargin{3:end});
+%     end
+% end
+% end

--- a/PIETOOLS/opvar/@opvar/horzcat.m
+++ b/PIETOOLS/opvar/@opvar/horzcat.m
@@ -1,12 +1,15 @@
 function [Pcat] = horzcat(varargin) 
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
-% [Pcat] = horzcat(varargin) takes n-inputs and concatentates them horizontally,
-% provided they satisfy the following criterias.
-% 1) Atleast one input is an opvar variable.
-% 2) If all the inputs are not opvar, then the operator maps from RxL2 to
-%    L2 or R to R. 
-% 3) Currently, it supports RxL2 to RxL2 concatenation only if ALL the inputs are
-%    opvar.
+% [Pcat] = horzcat(varargin) takes n inputs and concatentates them horizontally,
+% provided they satisfy the following criteria:
+% 1) All inputs must of type 'opvar';
+% 2) The output dimensions varargin{j}.dim(:,1) of all opvar objects must
+%       match;
+% 3) The spatial variables varargin{j}.var1 and varargin{j}.var2, as well 
+%       as the domain varargin{j}.I of all opvar objects must match;
+% 4) Concatenation should make sense within the context of the opvar class,
+%       that is, opvars take inputs from RxL2, never from L2xR. We cannot
+%       concatenate e.g. [A,B] for A:L2-->R and B:R-->R.
 % 
 % NOTES:
 % For support, contact M. Peet, Arizona State University at mpeet@asu.edu
@@ -41,95 +44,190 @@ function [Pcat] = horzcat(varargin)
 % SS - 8/27/19 added dimension correction to work with new opvar class that
 % has automatic dimension calculation
 % Adjusted so that dpvar with opvar returns dopvar, DJ 12/30/2021.
+% DJ - 09/30/23: Prohibit "ambiguous" concatenations.
 
-
+% Deal with single input case
 if nargin==1
     Pcat = varargin{1};
-else
-    a = varargin{1};
-    b = varargin{2};
-    
-    opvar Pcat;
-    if isa(a,'opvar')
-        Pcat.I = a.I; Pcat.var1 = a.var1; Pcat.var2 = a.var2;
-    elseif isa(b,'opvar')
-        Pcat.I = b.I; Pcat.var1 = b.var1; Pcat.var2 = b.var2;
-    elseif isa(a,'opvar')&&isa(b,'opvar')
-        if any(a.I~=b.I)||(a.var1~=b.var1)||(a.var2~=b.var2)
-            error('Operators being concatenated have different intervals or different independent variables');
-        end
-    end
-    if isa(a,'opvar') % correction to make components have consistent dimensions 8/27-ss
-        a.dim = a.dim;
-    end
-    if isa(b,'opvar') % correction to make components have consistent dimensions 8/27-ss
-        b.dim = b.dim;
-    end
-    
-    if isa(a,'dpvar')  % DJ, 12/30/2021
-        b = opvar2dopvar(b);
-        Pcat = horzcat(a,b);
-    elseif isa(b,'dpvar')
-        a = opvar2dopvar(a);
-        Pcat = horzcat(a,b);
-    elseif ~isa(a,'opvar')
-        if ~isa(b,'opvar') % both are not opvar variables
-            if size(a,1)~=size(b,1) 
-                error('Cannot concatentate horizontally. A and B have different output dimensions');
-            end
-            Pcat = [a b];
-        elseif b.dim(1,1)==0 % a() is from R to L2, Note: L2 to L2 needs to be an opvar
-            if size(a,1)~=b.dim(2,1) 
-                error('Cannot concatentate horizontally. A and B have different output dimensions');
-            end 
-%             Pcat = b;
-            Pcat.Q2 = [a b.Q2];
-            Pcat.P = [zeros(b.dim(1,1),size(a,2)) b.P];
-        elseif b.dim(2,1)==0 % a() is from R to R, Note: L2 to R needs to be an opvar
-            if size(a,1)~=b.dim(1,1) 
-                error('Cannot concatentate horizontally. A and B have different output dimensions');
-            end
-%             Pcat = b;
-            Pcat.P = [a b.P];
-            Pcat.Q2 = [zeros(b.dim(2,1),size(a,2)) b.Q2];
-        else %find if such an operation is valid is any useful scenario and implement it
-            error('Cannot concatenate horizontally. This feature is not yet supported.');
-        end
-    elseif ~isa(b,'opvar')
-        if a.dim(1,1)==0 % b() is from R to L2, Note: L2 to L2 needs to be an opvar
-            if size(b,1)~=a.dim(2,1) 
-                error('Cannot concatentate horizontally. A and B have different output dimensions');
-            end
-%             Pcat = a;
-            Pcat.Q2 = [a.Q2 b];
-            Pcat.P = [a.P zeros(a.dim(1,1),size(b,2))];
-        elseif a.dim(2,1)==0 % b() is from R to R, Note: L2 to R needs to be an opvar
-            if size(b,1)~=a.dim(1,1) 
-                error('Cannot concatentate horizontally. A and B have different output dimensions');
-            end
-%             Pcat = a;
-            Pcat.P = [a.P b];
-            Pcat.Q2 = [a.Q2 zeros(a.dim(2,1),size(b,2))];
-        else %find if such a operation is valid is any useful scenario and implement it
-            error('Cannot concatenate horizontally.This feature is not yet supported.');
-        end
-    else
-        if any(b.dim(:,1)~=a.dim(:,1))
-            error('Cannot concatentate horizontally. A and B have different output dimensions');
-        end
-%         Pcat = a;
-        fset = {'P', 'Q1', 'Q2'};
+    return
+end
 
-        for i=fset
-            Pcat.(i{:}) = [a.(i{:}) b.(i{:})];
-        end
-        fset = {'R0','R1','R2'};
-        for i=fset
-            Pcat.R.(i{:}) = [a.R.(i{:}) b.R.(i{:})];
-        end
-    end
-    if nargin>2 % check if there are more than 2 objects that need to stacked
-        Pcat = horzcat(Pcat, varargin{3:end});
-    end
+% Extract the operators
+a = varargin{1};    b = varargin{2};
+
+% Currently support only opvar-opvar concatenation
+if ~isa(a,'opvar') || ~isa(b,'opvar')
+    error('Concatenation of opvar and non-opvar objects is ambiguous, and currently not supported')
 end
+% Check that domain and variables match
+if any(a.I~=b.I)|| ~strcmp(a.var1.varname,b.var1.varname) || ~strcmp(a.var2.varname,b.var2.varname)
+    error('Operators being concatenated have different intervals or different independent variables');
 end
+% Check that the output dimensions match
+a.dim = a.dim;  b.dim = b.dim;  % correction to make components have consistent dimensions 8/27-ss
+if any(a.dim(:,1)~=b.dim(:,1))
+    error('Cannot concatenate horizontally: Output dimensions of opvar objects do not match')
+end
+
+% Avoid "ambiguous" concatenations
+if (a.dim(2,2)~=0 && b.dim(1,2)~=0)
+    % a has columns mapping from L2, but b has columns mapping from R.
+    % Concatenation would place those columns of a to the right of
+    % those columns of b in the opvar, which we currently prohibit...
+    error('Proposed opvar concatenation is ambiguous, and currently prohibited')
+end
+
+% Finally, let's actually concatenate
+opvar Pcat;
+Pcat.I = a.I;   Pcat.var1 = a.var1;     Pcat.var2 = a.var2;
+fset = {'P', 'Q1', 'Q2'};
+for i=fset
+    Pcat.(i{:}) = [a.(i{:}) b.(i{:})];
+end
+fset = {'R0','R1','R2'};
+for i=fset
+    Pcat.R.(i{:}) = [a.R.(i{:}) b.R.(i{:})];
+end
+
+% For concatenation of more than two objects, just repeat
+if nargin>2 
+    Pcat = horzcat(Pcat, varargin{3:end});
+end
+
+end
+
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+%%%%%%%%%%  Old version, that allows "ambiguous" concatenation   %%%%%%%%%%
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+% [Pcat] = horzcat(varargin) takes n-inputs and concatentates them horizontally,
+% provided they satisfy the following criteria:
+% 1) Atleast one input is an opvar variable.
+% 2) If all the inputs are not opvar, then the operator maps from RxL2 to
+%    L2 or R to R. 
+% 3) Currently, it supports RxL2 to RxL2 concatenation only if ALL the inputs are
+%    opvar.
+% 
+% NOTES:
+% For support, contact M. Peet, Arizona State University at mpeet@asu.edu
+% or S. Shivakumar at sshivak8@asu.edu
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+% 
+% if nargin==1
+%     Pcat = varargin{1};
+% else
+%     a = varargin{1};
+%     b = varargin{2};
+%     
+%     opvar Pcat;
+%     if isa(a,'opvar')
+%         Pcat.I = a.I; Pcat.var1 = a.var1; Pcat.var2 = a.var2;
+%     elseif isa(b,'opvar')
+%         Pcat.I = b.I; Pcat.var1 = b.var1; Pcat.var2 = b.var2;
+%     elseif isa(a,'opvar')&&isa(b,'opvar')
+%         if any(a.I~=b.I)||(a.var1~=b.var1)||(a.var2~=b.var2)
+%             error('Operators being concatenated have different intervals or different independent variables');
+%         end
+%     end
+%     if isa(a,'opvar') % correction to make components have consistent dimensions 8/27-ss
+%         a.dim = a.dim;
+%     end
+%     if isa(b,'opvar') % correction to make components have consistent dimensions 8/27-ss
+%         b.dim = b.dim;
+%     end
+%     
+%     if isa(a,'dpvar')  % DJ, 12/30/2021
+%         b = opvar2dopvar(b);
+%         Pcat = horzcat(a,b);
+%     elseif isa(b,'dpvar')
+%         a = opvar2dopvar(a);
+%         Pcat = horzcat(a,b);
+%     elseif ~isa(a,'opvar')
+%         if ~isa(b,'opvar') % both are not opvar variables
+%             if size(a,1)~=size(b,1) 
+%                 error('Cannot concatentate horizontally. A and B have different output dimensions');
+%             end
+%             Pcat = [a b];
+%         elseif b.dim(1,1)==0
+%             % b:RxL2-->L2, assume a:R-->L2
+%             % NOTE: a:L2-->L2 must be specified as opvar
+%             if size(a,1)~=b.dim(2,1) 
+%                 error('Cannot concatentate horizontally. A and B have different output dimensions');
+%             end 
+%             %Pcat.P = [zeros(b.dim(1,1),size(a,2)), b.P];
+%             Pcat.Q2 = [a,b.Q2];
+%             Pcat.R.R0 = b.R.R0;
+%             Pcat.R.R1 = b.R.R1;
+%             Pcat.R.R2 = b.R.R2;
+% %             Pcat.Q2 = b.Q2;
+% %             Pcat.R.R0 = [a, b.R.R0];
+% %             Pcat.R.R1 = [zeros(b.dim(2,1),size(a,2)), b.R.R1];
+% %             Pcat.R.R2 = [zeros(b.dim(2,1),size(a,2)), b.R.R2];
+%         elseif b.dim(2,1)==0 
+%             % b:RxL2-->R, assume a:R-->R
+%             if size(a,1)~=b.dim(1,1) 
+%                 error('Cannot concatentate horizontally. A and B have different output dimensions');
+%             end
+%             if isa(a,'polynomial') || isa(b,'dpvar')
+%                 try a=double(a);
+%                 catch
+%                     error('Convert arguments to opvar for this concatenation')
+%                 end
+%             end
+%             Pcat.P = [a b.P];
+%             Pcat.Q1 = b.Q1;
+%             %Pcat.Q2 = [zeros(b.dim(2,1),size(a,2)) b.Q2];
+%         else %find if such an operation is valid is any useful scenario and implement it
+%             error('Cannot concatenate horizontally. This feature is not yet supported.');
+%         end
+%     elseif ~isa(b,'opvar')
+%         if a.dim(1,1)==0
+%             % a:RxL2-->L2, assume b:R-->L2
+%             % NOTE: b:L2-->L2 must be specified as opvar
+%             if size(b,1)~=a.dim(2,1) 
+%                 error('Cannot concatentate horizontally. A and B have different output dimensions');
+%             end
+%             %Pcat.P = [a.P zeros(a.dim(1,1),size(b,2))];
+%             Pcat.Q2 = [a.Q2, b];
+%             Pcat.R.R0 = a.R.R0;
+%             Pcat.R.R1 = a.R.R1;
+%             Pcat.R.R2 = a.R.R2;
+% %             Pcat.Q2 = a.Q2;
+% %             Pcat.R.R0 = [a.R.R0, b];
+% %             Pcat.R.R1 = [a.R.R1, zeros(a.dim(2,1),size(b,2))];
+% %             Pcat.R.R2 = [a.R.R2, zeros(a.dim(2,1),size(b,2))];
+%         elseif a.dim(2,1)==0
+%             % a:RxL2-->R, assume b:R-->R
+%             if size(b,1)~=a.dim(1,1) 
+%                 error('Cannot concatentate horizontally. A and B have different output dimensions');
+%             end
+%             if isa(a,'polynomial') || isa(b,'dpvar')
+%                 try a=double(a);
+%                 catch
+%                     error('Convert arguments to opvar for this concatenation')
+%                 end
+%             end
+%             Pcat.P = [a.P b];
+%             Pcat.Q1 = a.Q1;
+%             %Pcat.Q2 = [a.Q2 zeros(a.dim(2,1),size(b,2))];
+%         else %find if such a operation is valid is any useful scenario and implement it
+%             error('Cannot concatenate horizontally.This feature is not yet supported.');
+%         end
+%     else
+%         if any(b.dim(:,1)~=a.dim(:,1))
+%             error('Cannot concatentate horizontally. A and B have different output dimensions');
+%         end
+%         fset = {'P', 'Q1', 'Q2'};
+%         for i=fset
+%             Pcat.(i{:}) = [a.(i{:}) b.(i{:})];
+%         end
+%         fset = {'R0','R1','R2'};
+%         for i=fset
+%             Pcat.R.(i{:}) = [a.R.(i{:}) b.R.(i{:})];
+%         end
+%     end
+%     if nargin>2 % check if there are more than 2 objects that need to stacked
+%         Pcat = horzcat(Pcat, varargin{3:end});
+%     end
+% end

--- a/PIETOOLS/opvar/@opvar/vertcat.m
+++ b/PIETOOLS/opvar/@opvar/vertcat.m
@@ -1,12 +1,15 @@
 function [Pcat] = vertcat(varargin)
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
-% [Pcat] = vertcat(varargin) takes n-inputs and concatentates them vertically,
-% provided they satisfy the following criterias.
-% 1) Atleast one input is an opvar variable.
-% 2) If all the inputs are not opvar, then the operator maps from R to
-% RxL2 or L2 to L2. 
-% 3) Currently, it supports RxL2 to RxL2 concatenation only if ALL the inputs are
-% opvar.
+% [Pcat] = vertcat(varargin) takes n inputs and concatentates them vertically,
+% provided they satisfy the following criteria:
+% 1) All inputs must of type 'opvar';
+% 2) The input dimensions varargin{j}.dim(:,2) of all opvar objects must
+%       match;
+% 3) The spatial variables varargin{j}.var1 and varargin{j}.var2, as well 
+%       as the domain varargin{j}.I of all opvar objects must match;
+% 4) Concatenation should make sense within the context of the opvar class,
+%       that is, opvars always mapt to from RxL2, never to L2xR. We cannot
+%       concatenate e.g. [A;B] for A:R-->L2 and B:R-->R.
 %
 % NOTES:
 % For support, contact M. Peet, Arizona State University at mpeet@asu.edu
@@ -41,94 +44,191 @@ function [Pcat] = vertcat(varargin)
 % SS - 8/27/19 added dimension correction to work with new opvar class that
 % has automatic dimension calculation
 % Adjusted so that dpvar with opvar returns dopvar, DJ 12/30/2021.
+% DJ - 09/30/23: Prohibit "ambiguous" concatenations.
 
-
+% Deal with single input case
 if nargin==1
     Pcat = varargin{1};
-else
-    a = varargin{1};
-    b = varargin{2};
-    
-    opvar Pcat;
-    if isa(a,'opvar')
-        Pcat.I = a.I; Pcat.var1 = a.var1; Pcat.var2 = a.var2;
-    elseif isa(b,'opvar')
-        Pcat.I = b.I; Pcat.var1 = b.var1; Pcat.var2 = b.var2;
-    elseif isa(a,'opvar')&&isa(b,'opvar')
-        if any(a.I~=b.I)||(a.var1~=b.var1)||(a.var2~=b.var2)
-            error('Operators being concatenated have different intervals or different independent variables');
-        end
-    end
-    if isa(a,'opvar') % correction to make components have consistent dimensions 8/27-ss
-        a.dim = a.dim;
-    end
-    if isa(b,'opvar') % correction to make components have consistent dimensions 8/27-ss
-        b.dim = b.dim;
-    end
-    
-    if isa(a,'dpvar')  % DJ, 12/30/2021
-        b = opvar2dopvar(b);
-        Pcat = vertcat(a,b);
-    elseif isa(b,'dpvar')
-        a = opvar2dopvar(a);
-        Pcat = vertcat(a,b);
-    elseif ~isa(a,'opvar') 
-        if ~isa(b,'opvar')
-            if size(a,2)~=size(b,2)
-                error('Cannot concatentate vertically. A and B have different input dimensions');
-            end
-            Pcat = [a;b];
-        else
-            bdim = b.dim;
-            if size(a,2)~=sum(bdim(:,2))
-                error("Cannot concatentate vertically. A and B have different input dimensions");
-            end
-%             Pcat = b;
-            if bdim(2,2) ==0
-                Pcat.P = [a; b.P]; % a() is from R to R
-                Pcat.Q1 =[zeros(size(a,1),b.dim(2,2)); b.Q1];
-            elseif bdim(1,2)==0 % a() is from L2 to L2, Note: a() cannot be a matrix and map L2 to R 
-                Pcat.Q2 = [zeros(size(a,1),b.dim(1,2)); b.Q2];
-                Pcat.R.R0 = [a; b.R.R0];
-                Pcat.R.R1 = [zeros(size(a)); b.R.R1];
-                Pcat.R.R2 = [zeros(size(a)); b.R.R2];
-            else %find if such a operation is valid is any useful scenario and implement it
-                error('Cannot concatenate vertically. This feature is not yet supported.');
-            end
-        end
-    elseif ~isa(b,'opvar') 
-        adim = a.dim;
-        if size(b,2)~=sum(adim(:,2))
-            error("Cannot concatentate vertically. A and B have different input dimensions");
-        end
-%         Pcat = a;
-        if adim(2,2) ==0
-            Pcat.P = [a.P; b]; % b() is from R to R
-            Pcat.Q1 = [a.Q1; zeros(size(b,1),a.dim(2,2))];
-        elseif adim(1,2)==0 % b() is from L2 to L2, Note: b() cannot be L2 to R and not be opvar
-            Pcat.Q2 = [a.Q2; zeros(size(b,1),a.dim(1,2))];
-            Pcat.R.R0 = [a.R.R0; b];
-            Pcat.R.R1 = [a.R.R1; zeros(size(b))];
-            Pcat.R.R2 = [a.R.R2; zeros(size(b))];
-        else %find if such a operation is valid is any useful scenario and implement it
-            error('Cannot concatenate vertically. This feature is not yet supported.');
-        end
-    else
-        if any(b.dim(:,2)~=a.dim(:,2))
-            error("Cannot concatentate vertically. A and B have different input dimensions");
-        end
-%         Pcat = a;
-        fset = {'P', 'Q1', 'Q2'};
-        for i=fset
-            Pcat.(i{:}) = [a.(i{:}); b.(i{:})];
-        end
-        fset = {'R0','R1','R2'};
-        for i=fset
-            Pcat.R.(i{:}) = [a.R.(i{:}); b.R.(i{:})];
-        end
-    end
-    if nargin>2 % Continue concatenation if inputs are more than 2
-        Pcat = vertcat(Pcat, varargin{3:end});
-    end
+    return
 end
+
+% Extract the operators
+a = varargin{1};    b = varargin{2};
+
+% Currently support only opvar-opvar concatenation
+if ~isa(a,'opvar') || ~isa(b,'opvar')
+    error('Concatenation of opvar and non-opvar objects is ambiguous, and currently not supported')
 end
+% Check that domain and variables match
+if any(a.I~=b.I)|| ~strcmp(a.var1.varname,b.var1.varname) || ~strcmp(a.var2.varname,b.var2.varname)
+    error('Operators being concatenated have different intervals or different independent variables');
+end
+% Check that the output dimensions match
+a.dim = a.dim;  b.dim = b.dim;  % correction to make components have consistent dimensions 8/27-ss
+if any(a.dim(:,2)~=b.dim(:,2))
+    error('Cannot concatenate vertically: Input dimensions of opvar objects do not match')
+end
+
+% Avoid "ambiguous" concatenations
+if (a.dim(2,1)~=0 && b.dim(1,1)~=0)
+    % a has rows mapping to L2, but b has rows mapping to R.
+    % Concatenation would place those rows of a below those of b in the
+    % opvar, which we currently prohibit...
+    error('Proposed opvar concatenation is ambiguous, and currently prohibited')
+end
+
+% Finally, let's actually concatenate
+opvar Pcat;
+Pcat.I = a.I;   Pcat.var1 = a.var1;     Pcat.var2 = a.var2;
+fset = {'P', 'Q1', 'Q2'};
+for i=fset
+    Pcat.(i{:}) = [a.(i{:}); b.(i{:})];
+end
+fset = {'R0','R1','R2'};
+for i=fset
+    Pcat.R.(i{:}) = [a.R.(i{:}); b.R.(i{:})];
+end
+
+% For concatenation of more than two objects, just repeat
+if nargin>2 
+    Pcat = vertcat(Pcat, varargin{3:end});
+end
+
+end
+
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+%%%%%%%%%%  Old version, that allows "ambiguous" concatenation   %%%%%%%%%%
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+% [Pcat] = vertcat(varargin) takes n-inputs and concatentates them vertically,
+% provided they satisfy the following criteria:
+% 1) Atleast one input is an opvar variable.
+% 2) If all the inputs are not opvar, then the operator maps from R to
+% RxL2 or L2 to L2. 
+% 3) Currently, it supports RxL2 to RxL2 concatenation only if ALL the inputs are
+% opvar.
+%
+% NOTES:
+% For support, contact M. Peet, Arizona State University at mpeet@asu.edu
+% or S. Shivakumar at sshivak8@asu.edu
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+%
+% if nargin==1
+%     Pcat = varargin{1};
+% else
+%     a = varargin{1};
+%     b = varargin{2};
+%     
+%     opvar Pcat;
+%     if isa(a,'opvar')
+%         Pcat.I = a.I; Pcat.var1 = a.var1; Pcat.var2 = a.var2;
+%     elseif isa(b,'opvar')
+%         Pcat.I = b.I; Pcat.var1 = b.var1; Pcat.var2 = b.var2;
+%     elseif isa(a,'opvar')&&isa(b,'opvar')
+%         if any(a.I~=b.I)||(a.var1~=b.var1)||(a.var2~=b.var2)
+%             error('Operators being concatenated have different intervals or different independent variables');
+%         end
+%     end
+%     if isa(a,'opvar') % correction to make components have consistent dimensions 8/27-ss
+%         a.dim = a.dim;
+%     end
+%     if isa(b,'opvar') % correction to make components have consistent dimensions 8/27-ss
+%         b.dim = b.dim;
+%     end
+%     
+%     if isa(a,'dpvar')  % DJ, 12/30/2021
+%         b = opvar2dopvar(b);
+%         Pcat = vertcat(a,b);
+%     elseif isa(b,'dpvar')
+%         a = opvar2dopvar(a);
+%         Pcat = vertcat(a,b);
+%     elseif ~isa(a,'opvar') 
+%         if ~isa(b,'opvar')
+%             if size(a,2)~=size(b,2)
+%                 error('Cannot concatentate vertically. A and B have different input dimensions');
+%             end
+%             Pcat = [a;b];
+%         else
+%             bdim = b.dim;
+%             if size(a,2)~=sum(bdim(:,2))
+%                 error("Cannot concatentate vertically. A and B have different input dimensions");
+%             end
+% %             Pcat = b;
+%             if bdim(2,2) ==0
+%                 % b:R-->RxL2, assume a:R-->R
+%                 if isa(a,'polynomial') || isa(b,'dpvar')
+%                     try a=double(a);
+%                     catch
+%                         error('Convert arguments to opvar for this concatenation')
+%                     end
+%                 end
+%                 Pcat.P = [a; b.P]; % a() is from R to R
+%                 Pcat.Q1 = [zeros(size(a,1),b.dim(2,2)); b.Q1];
+%                 Pcat.Q2 = b.Q2;
+%             elseif bdim(1,2)==0 
+%                 % b:L2-->RxL2, assume a:L2-->R
+%                 % NOTE: a:L2-->L2 must be specified as opvar
+%                 %Pcat.Q2 = [zeros(size(a,1),bdim(1,2)); b.Q2];
+%                 Pcat.Q1 = [a; b.Q1];
+%                 Pcat.R.R0 = b.R.R0;
+%                 Pcat.R.R1 = b.R.R1;
+%                 Pcat.R.R2 = b.R.R2;
+% %                 Pcat.Q1 = b.Q1;
+% %                 Pcat.R.R0 = [a; b.R.R0];
+% %                 Pcat.R.R1 = [zeros(size(a)); b.R.R1];
+% %                 Pcat.R.R2 = [zeros(size(a)); b.R.R2];
+%             else %find if such a operation is valid is any useful scenario and implement it
+%                 error('Cannot concatenate vertically. This feature is not yet supported.');
+%             end
+%         end
+%     elseif ~isa(b,'opvar') 
+%         adim = a.dim;
+%         if size(b,2)~=sum(adim(:,2))
+%             error("Cannot concatentate vertically. A and B have different input dimensions");
+%         end
+% %         Pcat = a;
+%         if adim(2,2) ==0
+%             % a:R-->RxL2, assume b:R-->R
+%             if isa(b,'polynomial') || isa(b,'dpvar')
+%                 try b=double(b);
+%                 catch
+%                     error('Convert arguments to opvar for this concatenation')
+%                 end
+%             end
+%             Pcat.P = [a.P; b]; % b() is from R to R
+%             Pcat.Q1 = [a.Q1; zeros(size(b,1),a.dim(2,2))];
+%             Pcat.Q2 = a.Q2;
+%         elseif adim(1,2)==0 
+%             % a:L2-->RxL2, assume b:L2-->R
+%             % NOTE: b:L2-->L2 must be specified as opvar
+%             %Pcat.Q2 = [a.Q2; zeros(size(b,1),adim(1,2))];
+%             Pcat.Q1 = [a.Q1; b];
+%             Pcat.R.R0 = a.R.R0;
+%             Pcat.R.R1 = a.R.R1;
+%             Pcat.R.R2 = a.R.R2;
+% %             Pcat.Q1 = a.Q1;
+% %             Pcat.R.R0 = [a.R.R0; b];
+% %             Pcat.R.R1 = [a.R.R1; zeros(size(b))];
+% %             Pcat.R.R2 = [a.R.R2; zeros(size(b))];
+%         else %find if such a operation is valid is any useful scenario and implement it
+%             error('Cannot concatenate vertically. This feature is not yet supported.');
+%         end
+%     else
+%         if any(b.dim(:,2)~=a.dim(:,2))
+%             error("Cannot concatentate vertically. A and B have different input dimensions");
+%         end
+% %         Pcat = a;
+%         fset = {'P', 'Q1', 'Q2'};
+%         for i=fset
+%             Pcat.(i{:}) = [a.(i{:}); b.(i{:})];
+%         end
+%         fset = {'R0','R1','R2'};
+%         for i=fset
+%             Pcat.R.(i{:}) = [a.R.(i{:}); b.R.(i{:})];
+%         end
+%     end
+%     if nargin>2 % Continue concatenation if inputs are more than 2
+%         Pcat = vertcat(Pcat, varargin{3:end});
+%     end
+% end

--- a/PIETOOLS/parser/@terms/vertcat.m
+++ b/PIETOOLS/parser/@terms/vertcat.m
@@ -55,6 +55,8 @@ else
     zeroAB.dim = [0 0; objA.operator.dim(2,1) objB.operator.dim(2,2)]; 
     zeroBA.dim = [0 0; objB.operator.dim(2,1) objA.operator.dim(2,2)];
     
+    objA.operator.var2 = pvar('theta'); objB.operator.var2 = pvar('theta');
+
     tempoperator = [objA.operator zeroAB; zeroBA objB.operator];
     tempstatevec = vertcat(objA.statevec, objB.statevec);
     


### PR DESCRIPTION
When concatenating opvar (opvar2d, dopvar, dopvar2d) objects with non-opvar objects, there is some ambiguity regarding what spaces these non-opvar objects map to and from. Similarly, when concatenating e.g. objects [A;B] for A mapping to L2 and B mapping to R, the resulting object cannot be represented using the opvar class, since opvars can only map to RxL2, not to L2xR.

The proposed update will prohibit any such concatenations of opvar/opvar2d/dopvar/dopvar2d objects for which there is any ambiguity regarding what dimensions the resulting operator maps to/from.