### PR TITLE
Update PIETOOLS_Hinf_estimator.m

### DIFF
--- a/PIETOOLS/executives/PIETOOLS_Hinf_estimator.m
+++ b/PIETOOLS/executives/PIETOOLS_Hinf_estimator.m
@@ -144,6 +144,10 @@ else
     Pop=P1op;
 end
 
+% enforce strict positivity on the operator
+Pop.P = Pop.P+eppos*eye(nx1);
+Pop.R.R0 = Pop.R.R0+eppos2*eye(nx2);  
+
 [prog,Zop] = lpivar(prog,[PIE.T.dim(:,1),PIE.C2.dim(:,1)],X,ddZ);
 
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%


### PR DESCRIPTION
added option to make the storage function strictly positive in the estimator design executive. Just specify eppos and eppos2 as zeroes when strict is not needed.