### PR TITLE
Reverting concatenation to allow some matrix-opvar concatenations

### DIFF
--- a/PIETOOLS/opvar/@dopvar/horzcat.m
+++ b/PIETOOLS/opvar/@dopvar/horzcat.m
@@ -57,10 +57,23 @@ end
 % Extract the operators
 a = varargin{1};    b = varargin{2};
 
-% Currently support only opvar-opvar concatenation
-if (~isa(a,'opvar') && ~isa(a,'dopvar')) || (~isa(b,'opvar') && ~isa(b,'dopvar'))
-    error('dopvar  objects can only be concatenated with opvar and dopvar objects')
+% Currently support only some matrix-opvar concatenation
+if (~isa(b,'dopvar')&&~isa(b,'opvar'))
+    error("Ambiguous concatenation [a,b] of opvars. Please explicitly define 'a' and 'b' as opvars to resolve.");
+elseif (~isa(a,'opvar')&&~isa(a,'dopvar')) && (isa(a,'double')||isa(a,'polynomial')||isa(a,'dpvar'))
+    opvar tmp; tmp.I = b.I; tmp.var1 = b.var1; tmp.var2 = b.var2;
+    if b.dim(2,1)~=0 % b maps to L2, so [a,b] is possible only if a is multiplier Q2 (or R0, but we ignore that)
+        tmp.Q2 = a;
+    elseif b.dim(1,1)~=0 && (isa(a,'double')||isempty(a.degmat)) % b maps to R, [a,b] is possible only if a is multiplier P
+        tmp.P = a;
+    else
+        error("Ambiguous concatenation [a,b] of opvars. Explicitly define 'a' and 'b' as opvars to resolve.");
+    end
+    tmp.dim = tmp.dim; % rectify dimensions
+    a = tmp;
+    clear tmp;
 end
+
 % Check that domain and variables match
 if any(a.I~=b.I)|| ~strcmp(a.var1.varname,b.var1.varname) || ~strcmp(a.var2.varname,b.var2.varname)
     error('Operators being concatenated have different intervals or different independent variables');

--- a/PIETOOLS/opvar/@dopvar/horzcat.m
+++ b/PIETOOLS/opvar/@dopvar/horzcat.m
@@ -60,7 +60,14 @@ a = varargin{1};    b = varargin{2};
 
 % Currently support only some matrix-opvar concatenation
 if (~isa(b,'dopvar')&&~isa(b,'opvar'))
-    error("Ambiguous concatenation [a,b] of opvars. Please explicitly define 'a' and 'b' as opvars to resolve.");
+    % Only supported if a in fact corresponds to a matrix as well
+    if all(a.dim(2,:)==0)
+        opvar tmp; tmp.I = a.I; tmp.var1 = a.var1; tmp.var2 = a.var2;
+        tmp.P = b;
+        b = tmp;
+    else
+        error("Ambiguous concatenation [a,b] of dopvars. Please explicitly define 'a' and 'b' as dopvars to resolve.");
+    end
 elseif (~isa(a,'opvar')&&~isa(a,'dopvar')) && (isa(a,'double')||isa(a,'polynomial')||isa(a,'dpvar'))
     opvar tmp; tmp.I = b.I; tmp.var1 = b.var1; tmp.var2 = b.var2;
     if b.dim(2,1)~=0 % b maps to L2, so [a,b] is possible only if a is multiplier Q2 (or R0, but we ignore that)

--- a/PIETOOLS/opvar/@dopvar/horzcat.m
+++ b/PIETOOLS/opvar/@dopvar/horzcat.m
@@ -2,8 +2,8 @@ function [Pcat] = horzcat(varargin)
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 % [Pcat] = horzcat(varargin) takes n inputs and concatentates them horizontally,
 % provided they satisfy the following criteria:
-% 1) At least one input must be of type 'dopvar', and all others must be of
-%       type 'opvar' or 'dopvar';
+% 1) At least one input must be of type 'dopvar', remaining inputs can be
+%    of type 'double', 'polynomial', 'opvar', or 'dopvar'.
 % 2) The output dimensions varargin{j}.dim(:,1) of all objects must match;
 % 3) The spatial variables varargin{j}.var1 and varargin{j}.var2, as well 
 %       as the domain varargin{j}.I of all objects must match;
@@ -47,6 +47,7 @@ function [Pcat] = horzcat(varargin)
 % are polynomials or just opvars
 % DJ - 12/30/2021 Adjusted to assure opvar with dopvar returns dopvar
 % DJ - 09/30/23: Prohibit "ambiguous" concatenations.
+% SS - 10/09/24: Revert to allow some matrix-opvar concatenations.
 
 % Deal with single input case
 if nargin==1
@@ -72,6 +73,8 @@ elseif (~isa(a,'opvar')&&~isa(a,'dopvar')) && (isa(a,'double')||isa(a,'polynomia
     tmp.dim = tmp.dim; % rectify dimensions
     a = tmp;
     clear tmp;
+elseif ~isa(a,'opvar') && ~isa(a,'dopvar')
+    error("Concatenation of 'dopvar' objects is only supported with objects of type 'dopvar', 'opvar', 'polynomial', or 'double'.")
 end
 
 % Check that domain and variables match

--- a/PIETOOLS/opvar/@dopvar/vertcat.m
+++ b/PIETOOLS/opvar/@dopvar/vertcat.m
@@ -54,7 +54,14 @@ end
 a = varargin{1};    b = varargin{2};
 
 if (~isa(b,'opvar') &&~isa(b,'dopvar'))
-    error("Ambiguous concatenation [a;b] of opvars. Please explicitly define 'a' and 'b' as opvars to resolve.");
+    % Only supported if a in fact corresponds to a matrix as well
+    if all(a.dim(2,:)==0)
+        opvar tmp; tmp.I = a.I; tmp.var1 = a.var1; tmp.var2 = a.var2;
+        tmp.P = b;
+        b = tmp;
+    else
+        error("Ambiguous concatenation [a;b] of dopvars. Please explicitly define 'a' and 'b' as dopvars to resolve.");
+    end
 elseif (~isa(a,'opvar')&&~isa(a,'dopvar')) && (isa(a,'double')||isa(a,'polynomial')||isa(a,'dpvar'))
     opvar tmp; tmp.I = b.I; tmp.var1 = b.var1; tmp.var2 = b.var2;
     if b.dim(2,2)~=0 % b from L2, so [a;b] is possible only if a is integral Q1 (or multiplier R0, but we ignore that)

--- a/PIETOOLS/opvar/@dopvar/vertcat.m
+++ b/PIETOOLS/opvar/@dopvar/vertcat.m
@@ -52,9 +52,20 @@ end
 % Extract the operators
 a = varargin{1};    b = varargin{2};
 
-% Currently support only opvar-opvar concatenation
-if (~isa(a,'opvar') && ~isa(a,'dopvar')) || (~isa(b,'opvar') && ~isa(b,'dopvar'))
-    error('dopvar  objects can only be concatenated with opvar and dopvar objects')
+if (~isa(b,'opvar') &&~isa(b,'dopvar'))
+    error("Ambiguous concatenation [a;b] of opvars. Please explicitly define 'a' and 'b' as opvars to resolve.");
+elseif (~isa(a,'opvar')&&~isa(a,'dopvar')) && (isa(a,'double')||isa(a,'polynomial')||isa(a,'dpvar'))
+    opvar tmp; tmp.I = b.I; tmp.var1 = b.var1; tmp.var2 = b.var2;
+    if b.dim(2,2)~=0 % b from L2, so [a;b] is possible only if a is integral Q1 (or multiplier R0, but we ignore that)
+        tmp.Q1 = a;
+    elseif b.dim(1,2)~=0 && (isa(a,'double')||isempty(a.degmat)) % b maps from R, [a;b] is possible only if a is multiplier P (or Q2, but we ignore that)
+        tmp.P = a;
+    else
+        error("Ambiguous concatenation [a;b] of opvars. Explicitly define 'a' and 'b' as opvars to resolve.");
+    end
+    tmp.dim = tmp.dim; % rectify dimensions
+    a = tmp;
+    clear tmp;
 end
 % Check that domain and variables match
 if any(a.I~=b.I)|| ~strcmp(a.var1.varname,b.var1.varname) || ~strcmp(a.var2.varname,b.var2.varname)

--- a/PIETOOLS/opvar/@dopvar/vertcat.m
+++ b/PIETOOLS/opvar/@dopvar/vertcat.m
@@ -2,8 +2,8 @@ function [Pcat] = vertcat(varargin)
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 % [Pcat] = vertcat(varargin) takes n inputs and concatentates them vertically,
 % provided they satisfy the following criteria:
-% 1) At least one input must be of type 'dopvar', and all others must be of
-%       type 'opvar' or 'dopvar';
+% 1) At least one input must be of type 'dopvar', remaining inputs can be
+%    of type 'double', 'polynomial', 'opvar', or 'dopvar'.
 % 2) The input dimensions varargin{j}.dim(:,2) of all objects must match;
 % 3) The spatial variables varargin{j}.var1 and varargin{j}.var2, as well 
 %       as the domain varargin{j}.I of all objects must match;
@@ -42,6 +42,7 @@ function [Pcat] = vertcat(varargin)
 % DJ, 09/29/2021: Small adjustment to avoid error with dopvar-opvar concatenation
 % DJ, 12/30/2021: Adjusted to assure opvar with dopvar returns dopvar
 % DJ - 09/30/23: Prohibit "ambiguous" concatenations.
+% SS - 10/09/24: Revert to allow some matrix-opvar concatenations.
 
 % Deal with single input case
 if nargin==1
@@ -66,6 +67,8 @@ elseif (~isa(a,'opvar')&&~isa(a,'dopvar')) && (isa(a,'double')||isa(a,'polynomia
     tmp.dim = tmp.dim; % rectify dimensions
     a = tmp;
     clear tmp;
+elseif ~isa(a,'opvar') && ~isa(a,'dopvar')
+    error("Concatenation of 'dopvar' objects is only supported with objects of type 'dopvar', 'opvar', 'polynomial', or 'double'.")
 end
 % Check that domain and variables match
 if any(a.I~=b.I)|| ~strcmp(a.var1.varname,b.var1.varname) || ~strcmp(a.var2.varname,b.var2.varname)

--- a/PIETOOLS/opvar/@opvar/horzcat.m
+++ b/PIETOOLS/opvar/@opvar/horzcat.m
@@ -59,7 +59,14 @@ a = varargin{1};    b = varargin{2};
 
 % Currently support some matrix-opvar concatenation
 if ~isa(b,'opvar')
-    error("Ambiguous concatenation [a,b] of opvars. Please explicitly define 'a' and 'b' as opvars to resolve.");
+    % Only supported if a in fact corresponds to a matrix as well
+    if all(a.dim(2,:)==0)
+        opvar tmp; tmp.I = a.I; tmp.var1 = a.var1; tmp.var2 = a.var2;
+        tmp.P = b;
+        b = tmp;
+    else
+        error("Ambiguous concatenation [a,b] of opvars. Please explicitly define 'a' and 'b' as opvars to resolve.");
+    end
 elseif ~isa(a,'opvar') && (isa(a,'double')||isa(a,'polynomial')||isa(a,'dpvar'))
     opvar tmp; tmp.I = b.I; tmp.var1 = b.var1; tmp.var2 = b.var2;
     if b.dim(2,1)~=0 % b maps to L2, so [a,b] is possible only if a is multiplier Q2 (or R0, but we ignore that)

--- a/PIETOOLS/opvar/@opvar/horzcat.m
+++ b/PIETOOLS/opvar/@opvar/horzcat.m
@@ -2,7 +2,8 @@ function [Pcat] = horzcat(varargin)
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 % [Pcat] = horzcat(varargin) takes n inputs and concatentates them horizontally,
 % provided they satisfy the following criteria:
-% 1) All inputs must of type 'opvar';
+% 1) At least one input must be of type 'opvar', remaining inputs can be of
+%    type 'double', 'polynomial', or 'opvar'.
 % 2) The output dimensions varargin{j}.dim(:,1) of all opvar objects must
 %       match;
 % 3) The spatial variables varargin{j}.var1 and varargin{j}.var2, as well 
@@ -45,6 +46,7 @@ function [Pcat] = horzcat(varargin)
 % has automatic dimension calculation
 % Adjusted so that dpvar with opvar returns dopvar, DJ 12/30/2021.
 % DJ - 09/30/23: Prohibit "ambiguous" concatenations.
+% SS - 10/09/24: Revert to allow some matrix-opvar concatenations.
 
 % Deal with single input case
 if nargin==1
@@ -70,6 +72,8 @@ elseif ~isa(a,'opvar') && (isa(a,'double')||isa(a,'polynomial')||isa(a,'dpvar'))
     tmp.dim = tmp.dim; % rectify dimensions
     a = tmp;
     clear tmp;
+elseif ~isa(a,'opvar')
+    error("Concatenation of 'opvar' objects is only supported with objects of type 'opvar', 'polynomial', or 'double'.")
 end
 
 

--- a/PIETOOLS/opvar/@opvar/vertcat.m
+++ b/PIETOOLS/opvar/@opvar/vertcat.m
@@ -55,10 +55,24 @@ end
 % Extract the operators
 a = varargin{1};    b = varargin{2};
 
-% Currently support only opvar-opvar concatenation
-if ~isa(a,'opvar') || ~isa(b,'opvar')
-    error('Concatenation of opvar and non-opvar objects is ambiguous, and currently not supported')
+% Currently support some matrix-opvar concatenation
+if ~isa(b,'opvar')
+    error("Ambiguous concatenation [a;b] of opvars. Please explicitly define 'a' and 'b' as opvars to resolve.");
+elseif ~isa(a,'opvar') && (isa(a,'double')||isa(a,'polynomial')||isa(a,'dpvar'))
+    opvar tmp; tmp.I = b.I; tmp.var1 = b.var1; tmp.var2 = b.var2;
+    if b.dim(2,2)~=0 % b from L2, so [a;b] is possible only if a is integral Q1 (or multiplier R0, but we ignore that)
+        tmp.Q1 = a;
+    elseif b.dim(1,2)~=0 && (isa(a,'double')||isempty(a.degmat)) % b maps from R, [a;b] is possible only if a is multiplier P (or Q2, but we ignore that)
+        tmp.P = a;
+    else
+        error("Ambiguous concatenation [a;b] of opvars. Explicitly define 'a' and 'b' as opvars to resolve.");
+    end
+    tmp.dim = tmp.dim; % rectify dimensions
+    a = tmp;
+    clear tmp;
 end
+
+
 % Check that domain and variables match
 if any(a.I~=b.I)|| ~strcmp(a.var1.varname,b.var1.varname) || ~strcmp(a.var2.varname,b.var2.varname)
     error('Operators being concatenated have different intervals or different independent variables');

--- a/PIETOOLS/opvar/@opvar/vertcat.m
+++ b/PIETOOLS/opvar/@opvar/vertcat.m
@@ -59,7 +59,14 @@ a = varargin{1};    b = varargin{2};
 
 % Currently support some matrix-opvar concatenation
 if ~isa(b,'opvar')
-    error("Ambiguous concatenation [a;b] of opvars. Please explicitly define 'a' and 'b' as opvars to resolve.");
+    % Only supported if a in fact corresponds to a matrix as well
+    if all(a.dim(2,:)==0)
+        opvar tmp; tmp.I = a.I; tmp.var1 = a.var1; tmp.var2 = a.var2;
+        tmp.P = b;
+        b = tmp;
+    else
+        error("Ambiguous concatenation [a;b] of opvars. Please explicitly define 'a' and 'b' as opvars to resolve.");
+    end
 elseif ~isa(a,'opvar') && (isa(a,'double')||isa(a,'polynomial')||isa(a,'dpvar'))
     opvar tmp; tmp.I = b.I; tmp.var1 = b.var1; tmp.var2 = b.var2;
     if b.dim(2,2)~=0 % b from L2, so [a;b] is possible only if a is integral Q1 (or multiplier R0, but we ignore that)

--- a/PIETOOLS/opvar/@opvar/vertcat.m
+++ b/PIETOOLS/opvar/@opvar/vertcat.m
@@ -2,7 +2,8 @@ function [Pcat] = vertcat(varargin)
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 % [Pcat] = vertcat(varargin) takes n inputs and concatentates them vertically,
 % provided they satisfy the following criteria:
-% 1) All inputs must of type 'opvar';
+% 1) At least one input must be of type 'opvar', remaining inputs can be of
+%    type 'double', 'polynomial', or 'opvar'.
 % 2) The input dimensions varargin{j}.dim(:,2) of all opvar objects must
 %       match;
 % 3) The spatial variables varargin{j}.var1 and varargin{j}.var2, as well 
@@ -45,6 +46,7 @@ function [Pcat] = vertcat(varargin)
 % has automatic dimension calculation
 % Adjusted so that dpvar with opvar returns dopvar, DJ 12/30/2021.
 % DJ - 09/30/23: Prohibit "ambiguous" concatenations.
+% SS - 10/09/24: Revert to allow some matrix-opvar concatenations.
 
 % Deal with single input case
 if nargin==1
@@ -70,6 +72,8 @@ elseif ~isa(a,'opvar') && (isa(a,'double')||isa(a,'polynomial')||isa(a,'dpvar'))
     tmp.dim = tmp.dim; % rectify dimensions
     a = tmp;
     clear tmp;
+elseif ~isa(a,'opvar')
+    error("Concatenation of 'opvar' objects is only supported with objects of type 'opvar', 'polynomial', or 'double'.")
 end
 
 


### PR DESCRIPTION
Ran some tests with random opvars/matrix/dpvar combos. Everything worked find. Does not break any demos or library examples either. **Only updated 1D case.** I don't know how 2d opvars/dopvars work.

Currently, the restrictions are as follows:

**horzcat** `[a,b]`
- `b` must be an opvar/dopvar (no exceptions)
- `a` can be opvar/dopvar/polynomial/dpvar/double
- if `a` is matrix... then we always assume `a`: \R  -> something (something is decided by `b`)

**vertcat** `[a;b]`
- `b` must be an opvar/dopvar (no exceptions)
- `a` can be opvar/dopvar/polynomial/dpvar/double
- if `a` is matrix... then we always assume `a`: something -> \R (something is decided by `b`)